### PR TITLE
feat: Apps Script router for all Workspace tools — no GCP project needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2026-04-17
+
+### Added
+- **Apps Script Router**: All 41 Workspace tools (Gmail, Drive, Sheets, Calendar, Docs, Forms, Tasks) now work through a per-user Apps Script Web App using clasp auth only — no GCP project required
+- Automatic backend selection: router when no OAuth credentials, REST API when configured
+- `MCP_USE_ROUTER` env var to force a specific backend (`true`, `false`, `auto`)
+- `gmcp auth` now deploys the router and prints the authorization URL
+- `gmcp status` shows router deployment state
+- Tasks implemented via `UrlFetchApp` REST calls (no advanced service dependency)
+
+### Fixed
+- clasp token parsing for new format (`{"tokens":{"default":{...}}}` vs `{"token":{...}}`)
+- Apps Script API enablement check in `gmcp auth` and `gmcp status`
+
+### Changed
+- README: added "Two Backends" comparison section and updated Quick Start with setup steps
+
 ## [0.1.0] - 2026-01-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -162,11 +162,29 @@ Workspace tools (Gmail, Drive, Sheets, etc.) can operate in two modes:
 
 | | **Clasp Router** (default) | **REST API** (with OAuth 2.1) |
 |---|---|---|
-| **Setup** | `gmcp auth` — one browser sign-in, no GCP project | Create GCP project, enable APIs, configure OAuth consent screen, create credentials |
-| **How it works** | Deploys an Apps Script Web App that calls `GmailApp`, `DriveApp`, etc. internally | Calls Google REST APIs directly with OAuth tokens |
-| **Latency** | ~1–3s per call (Apps Script cold starts) | ~100ms per call |
-| **Quotas** | [Apps Script daily limits](https://developers.google.com/apps-script/guides/services/quotas) (e.g., 100 emails/day on free Gmail) | REST API limits (higher) |
-| **Best for** | Personal use, quick setup, AI agents | High-volume, production, low-latency |
+| **Setup time** | ~2 min (browser sign-in + one toggle + one Allow click) | ~15 min (GCP project + enable APIs + OAuth consent screen + credentials) |
+| **GCP project** | Not needed | Required |
+| **How it works** | Deploys an Apps Script Web App per user; tool calls routed via HTTP POST | Calls Google REST APIs directly with OAuth tokens |
+| **Latency** | ~1–3s per call (Apps Script execution overhead) | ~100–300ms per call |
+| **Execution timeout** | 30s per call (Apps Script limit) | No per-call limit |
+| **Best for** | Personal use, prototyping, AI agents | High-volume, production, low-latency apps |
+
+### Daily quotas (free consumer Google account)
+
+| Service | Clasp Router (Apps Script limits) | REST API limits |
+|---------|----------------------------------|-----------------|
+| **Gmail send** | 100 recipients/day | 500 emails/day (Gmail API) |
+| **Gmail read** | 50,000 reads/day | 250 quota units/s per user |
+| **Drive** | 90 min total runtime/day | 1 billion API calls/day (project) |
+| **Sheets** | 90 min total runtime/day | 300 requests/min per project |
+| **Calendar** | 5,000 events created/day | 1M queries/day per project |
+| **Docs** | 90 min total runtime/day | 300 requests/min per project |
+| **Forms** | 90 min total runtime/day | No published limit |
+| **Tasks** | Same as REST (calls Tasks API via `UrlFetchApp`) | 50,000 requests/day |
+
+> **Note:** Apps Script runtime limits are shared across all services. The 90 min/day limit applies to total execution time, not per-service. At ~2s per call, that's ~2,700 tool calls/day. [Full Apps Script quotas](https://developers.google.com/apps-script/guides/services/quotas)
+
+### Backend selection
 
 The backend is selected automatically: if `GOOGLE_OAUTH_CLIENT_ID` and `GOOGLE_OAUTH_CLIENT_SECRET` are set, REST APIs are used. Otherwise, the clasp router handles Workspace calls.
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,12 @@ Uses [clasp](https://github.com/google/clasp) for authentication. No GCP console
 ## Quick Start
 
 ```bash
-uvx google-automation-mcp        # Run server
 uvx google-automation-mcp auth   # Authenticate (one-time browser sign-in)
+uvx google-automation-mcp        # Run server
 ```
+
+After auth, enable the **Apps Script API** (one-time, 5 seconds):
+→ https://script.google.com/home/usersettings — toggle ON.
 
 That's it. No GCP project setup. Tokens auto-refresh after initial auth.
 
@@ -146,6 +149,22 @@ export GOOGLE_OAUTH_CLIENT_ID='...'
 export GOOGLE_OAUTH_CLIENT_SECRET='...'
 gmcp auth --oauth21
 ```
+
+## Two Backends: Clasp Router vs REST API
+
+Workspace tools (Gmail, Drive, Sheets, etc.) can operate in two modes:
+
+| | **Clasp Router** (default) | **REST API** (with OAuth 2.1) |
+|---|---|---|
+| **Setup** | `gmcp auth` — one browser sign-in, no GCP project | Create GCP project, enable APIs, configure OAuth consent screen, create credentials |
+| **How it works** | Deploys an Apps Script Web App that calls `GmailApp`, `DriveApp`, etc. internally | Calls Google REST APIs directly with OAuth tokens |
+| **Latency** | ~1–3s per call (Apps Script cold starts) | ~100ms per call |
+| **Quotas** | [Apps Script daily limits](https://developers.google.com/apps-script/guides/services/quotas) (e.g., 100 emails/day on free Gmail) | REST API limits (higher) |
+| **Best for** | Personal use, quick setup, AI agents | High-volume, production, low-latency |
+
+The backend is selected automatically: if `GOOGLE_OAUTH_CLIENT_ID` and `GOOGLE_OAUTH_CLIENT_SECRET` are set, REST APIs are used. Otherwise, the clasp router handles Workspace calls.
+
+Override with `MCP_USE_ROUTER=true` or `MCP_USE_ROUTER=false` to force a specific backend.
 
 ## CLI Reference
 

--- a/README.md
+++ b/README.md
@@ -10,16 +10,22 @@ Uses [clasp](https://github.com/google/clasp) for authentication. No GCP console
 ## Quick Start
 
 ```bash
-uvx google-automation-mcp auth   # Authenticate (one-time browser sign-in)
-uvx google-automation-mcp        # Run server
+uvx google-automation-mcp auth   # 1. Browser sign-in via clasp
+uvx google-automation-mcp        # 4. Run server
 ```
 
-After auth, enable the **Apps Script API** (one-time, 5 seconds):
-→ https://script.google.com/home/usersettings — toggle ON.
+First run walks you through three one-time steps:
 
-That's it. No GCP project setup. Tokens auto-refresh after initial auth.
+1. **`gmcp auth`** — opens browser for Google sign-in (clasp OAuth)
+2. **Enable Apps Script API** — `gmcp auth` checks and prompts you to toggle ON at https://script.google.com/home/usersettings (5 seconds)
+3. **Authorize scopes** — `gmcp auth` deploys a Web App router and prints a URL. Open it, click "Allow" to grant Gmail/Drive/Sheets/Calendar/Docs/Forms/Tasks access
+4. **Done** — run `gmcp` or `uvx google-automation-mcp` to start the server
+
+Check status anytime: `gmcp status`
 
 > **Tip:** Use the short alias `gmcp` after installing.
+
+> **Re-authorization:** If a future update adds new scopes, revoke the app at [myaccount.google.com/permissions](https://myaccount.google.com/permissions) (find "MCP-Router"), then visit the Web App URL again from `gmcp status`.
 
 ## Why No GCP Project?
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "google-automation-mcp"
-version = "0.6.0"
+version = "0.7.0"
 description = "Headless Google Workspace automation for AI - Apps Script, Gmail, Drive, Sheets, Calendar, Docs, Tasks, Forms"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/google_automation_mcp/__init__.py
+++ b/src/google_automation_mcp/__init__.py
@@ -5,7 +5,7 @@ MCP server for Google Apps Script and Google Workspace automation.
 Supports 50 tools across Gmail, Drive, Sheets, Calendar, Docs, and Apps Script.
 """
 
-__version__ = "0.5.2"
+__version__ = "0.7.0"
 
 # Cache for lazy-loaded modules to avoid recursion
 _lazy_cache = {}

--- a/src/google_automation_mcp/auth/clasp.py
+++ b/src/google_automation_mcp/auth/clasp.py
@@ -72,6 +72,17 @@ def get_clasp_version() -> Optional[str]:
     return None
 
 
+def _extract_clasp_token(config: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Extract token dict from clasp config, handling both old and new formats."""
+    # Old format: {"token": {...}}
+    if "token" in config and isinstance(config["token"], dict):
+        return config["token"]
+    # New format: {"tokens": {"default": {...}}}
+    if "tokens" in config and isinstance(config["tokens"], dict):
+        return config["tokens"].get("default")
+    return None
+
+
 def is_clasp_authenticated() -> bool:
     """Check if clasp has valid credentials stored."""
     if not CLASP_RC_PATH.exists():
@@ -80,7 +91,8 @@ def is_clasp_authenticated() -> bool:
     try:
         with open(CLASP_RC_PATH, "r") as f:
             config = json.load(f)
-        return "token" in config and config["token"].get("access_token")
+        token = _extract_clasp_token(config)
+        return token is not None and bool(token.get("access_token"))
     except (json.JSONDecodeError, IOError):
         return False
 
@@ -89,18 +101,7 @@ def get_clasp_tokens() -> Optional[Dict[str, Any]]:
     """
     Read tokens from clasp's credential file (~/.clasprc.json).
 
-    clasp token format:
-    {
-        "token": {
-            "access_token": "...",
-            "refresh_token": "...",
-            "scope": "https://www.googleapis.com/auth/... ...",
-            "token_type": "Bearer",
-            "expiry_date": 1234567890000,  // milliseconds
-            "client_id": "...",
-            "client_secret": "..."
-        }
-    }
+    Handles both old format {"token": {...}} and new format {"tokens": {"default": {...}}}.
 
     Returns:
         Token dict or None if not available.
@@ -111,7 +112,7 @@ def get_clasp_tokens() -> Optional[Dict[str, Any]]:
     try:
         with open(CLASP_RC_PATH, "r") as f:
             config = json.load(f)
-        return config.get("token")
+        return _extract_clasp_token(config)
     except (json.JSONDecodeError, IOError) as e:
         logger.warning(f"Failed to read clasp tokens: {e}")
         return None

--- a/src/google_automation_mcp/cli.py
+++ b/src/google_automation_mcp/cli.py
@@ -104,6 +104,19 @@ def _run_status():
     else:
         print("  ? Cannot check (not authenticated)")
 
+    print("\nWorkspace Router:")
+    from .router.deployer import _load_state
+    users = env.get("existing_users", [])
+    if users:
+        state = _load_state(users[0])
+        if state and state.get("web_app_url"):
+            print(f"  ✓ Deployed for {users[0]}")
+            print(f"    URL: {state['web_app_url']}")
+        else:
+            print("  ✗ Not deployed (run: gmcp auth)")
+    else:
+        print("  ? No authenticated user")
+
     print("\nOAuth:")
     if env["oauth_configured"]:
         print("  ✓ GCP credentials configured")
@@ -247,15 +260,44 @@ def _auth_clasp(headless: bool = False):
         # Check Apps Script API is enabled
         print()
         print("Checking Apps Script API access...")
-        if _check_apps_script_api():
-            print("✓ Apps Script API is enabled")
-        else:
+        if not _check_apps_script_api():
             print("✗ Apps Script API is not enabled")
             print()
             print("  This is a one-time toggle (5 seconds):")
             print(f"  → {APPS_SCRIPT_API_URL}")
             print()
-            print("  Turn ON 'Google Apps Script API', then you're all set.")
+            print("  Turn ON 'Google Apps Script API', then re-run: gmcp auth")
+            return
+
+        print("✓ Apps Script API is enabled")
+
+        # Deploy router and get authorization URL
+        print()
+        print("Deploying Workspace router...")
+        try:
+            import asyncio
+            from .router.deployer import deploy_router
+            from .auth import get_credentials
+            from .auth.credential_store import get_credential_store
+
+            store = get_credential_store()
+            users = store.list_users()
+            email = users[0] if users else None
+
+            if email:
+                state = asyncio.run(deploy_router(email))
+                url = state["web_app_url"]
+                print("✓ Router deployed")
+                print()
+                print("Last step — authorize Workspace scopes (one-time):")
+                print(f"  → {url}")
+                print()
+                print("  Open this URL, sign in, click 'Allow', then you're all set.")
+            else:
+                print("✗ No authenticated user found for router deployment")
+        except Exception as e:
+            print(f"✗ Router deployment failed: {e}")
+            print("  You can deploy later — it will auto-deploy on first tool call.")
 
 
 def _auth_local_legacy():

--- a/src/google_automation_mcp/cli.py
+++ b/src/google_automation_mcp/cli.py
@@ -9,6 +9,8 @@ Provides:
 
 import sys
 
+APPS_SCRIPT_API_URL = "https://script.google.com/home/usersettings"
+
 
 def main():
     """Main CLI entry point."""
@@ -92,13 +94,23 @@ def _run_status():
     else:
         print("  ✗ Not installed")
 
+    print("\nApps Script API:")
+    if env.get("clasp_authenticated") or env.get("has_credentials"):
+        if _check_apps_script_api():
+            print("  ✓ Enabled")
+        else:
+            print("  ✗ Not enabled")
+            print(f"    → Enable at: {APPS_SCRIPT_API_URL}")
+    else:
+        print("  ? Cannot check (not authenticated)")
+
     print("\nOAuth:")
     if env["oauth_configured"]:
         print("  ✓ GCP credentials configured")
         if env["oauth21_enabled"]:
             print("  ✓ OAuth 2.1 enabled")
     else:
-        print("  ✗ GCP credentials not configured")
+        print("  ✗ GCP credentials not configured (not needed for clasp)")
 
     print()
 
@@ -140,6 +152,29 @@ def _print_version():
     except Exception:
         v = "unknown"
     print(f"google-automation-mcp {v}")
+
+
+def _check_apps_script_api() -> bool:
+    """Check if the Apps Script API is enabled for the user. Returns True if OK."""
+    from .auth import get_script_service, get_drive_service
+
+    try:
+        service = get_script_service()
+        # projects.create is the only reliable endpoint that returns the
+        # "User has not enabled" 403. If it succeeds, clean up immediately.
+        project = service.projects().create(body={"title": "_mcp_api_check"}).execute()
+        script_id = project.get("scriptId")
+        if script_id:
+            try:
+                drive = get_drive_service()
+                drive.files().delete(fileId=script_id).execute()
+            except Exception:
+                pass
+        return True
+    except Exception as e:
+        if "User has not enabled the Apps Script API" in str(e):
+            return False
+        return True
 
 
 def _auth_clasp(headless: bool = False):
@@ -208,6 +243,19 @@ def _auth_clasp(headless: bool = False):
         from .setup import _import_clasp_credentials
 
         _import_clasp_credentials()
+
+        # Check Apps Script API is enabled
+        print()
+        print("Checking Apps Script API access...")
+        if _check_apps_script_api():
+            print("✓ Apps Script API is enabled")
+        else:
+            print("✗ Apps Script API is not enabled")
+            print()
+            print("  This is a one-time toggle (5 seconds):")
+            print(f"  → {APPS_SCRIPT_API_URL}")
+            print()
+            print("  Turn ON 'Google Apps Script API', then you're all set.")
 
 
 def _auth_local_legacy():

--- a/src/google_automation_mcp/router/__init__.py
+++ b/src/google_automation_mcp/router/__init__.py
@@ -1,0 +1,11 @@
+"""
+Apps Script Web App Router
+
+Deploys a bundled Apps Script as a Web App per user,
+enabling Workspace tool calls via clasp auth only (no GCP project needed).
+"""
+
+from .client import call_router
+from .deployer import ensure_router_deployed
+
+__all__ = ["call_router", "ensure_router_deployed"]

--- a/src/google_automation_mcp/router/client.py
+++ b/src/google_automation_mcp/router/client.py
@@ -1,0 +1,87 @@
+"""
+Router Client
+
+Makes HTTP POST calls to the deployed Apps Script Web App router.
+"""
+
+import asyncio
+import json
+import logging
+from typing import Any, Dict, Optional
+from urllib.request import Request, urlopen
+from urllib.error import URLError, HTTPError
+
+from .deployer import ensure_router_deployed
+
+logger = logging.getLogger(__name__)
+
+_TIMEOUT = 30  # Apps Script max execution time
+
+
+class RouterError(Exception):
+    """Raised when the router returns an error."""
+
+    def __init__(self, message: str, code: int = 500):
+        super().__init__(message)
+        self.code = code
+
+
+async def call_router(
+    user_email: str,
+    action: str,
+    params: Optional[Dict[str, Any]] = None,
+) -> Any:
+    """
+    Call the Apps Script router for a user.
+
+    Ensures the router is deployed, then makes an HTTP POST with the
+    action and params. Returns the parsed result.
+
+    Args:
+        user_email: The user's Google email address
+        action: The router action name (e.g., 'search_gmail')
+        params: Parameters for the action
+
+    Returns:
+        The result from the Apps Script handler
+
+    Raises:
+        RouterError: If the router returns an error
+        ValueError: If the user has no deployed router and deployment fails
+    """
+    state = await ensure_router_deployed(user_email)
+    url = state["web_app_url"]
+    secret = state["secret"]
+
+    payload = json.dumps({
+        "secret": secret,
+        "action": action,
+        "params": params or {},
+    }).encode("utf-8")
+
+    def _do_request():
+        req = Request(
+            url,
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            with urlopen(req, timeout=_TIMEOUT) as resp:
+                body = resp.read().decode("utf-8")
+                return json.loads(body)
+        except HTTPError as e:
+            body = e.read().decode("utf-8", errors="replace")
+            raise RouterError(f"HTTP {e.code}: {body}", e.code)
+        except URLError as e:
+            raise RouterError(f"Connection error: {e.reason}")
+
+    result = await asyncio.to_thread(_do_request)
+
+    if "error" in result:
+        raise RouterError(
+            result["error"],
+            result.get("code", 500),
+        )
+
+    return result.get("result")

--- a/src/google_automation_mcp/router/deployer.py
+++ b/src/google_automation_mcp/router/deployer.py
@@ -1,0 +1,228 @@
+"""
+Router Deployer
+
+Creates and deploys the Apps Script Web App router per user.
+Uses the Apps Script API (via clasp auth) — no GCP project needed.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import secrets
+from pathlib import Path
+from typing import Optional, Dict, Any
+
+from googleapiclient.errors import HttpError
+
+from ..auth import get_script_service
+
+logger = logging.getLogger(__name__)
+
+ROUTER_STATE_DIR = Path.home() / ".secrets" / "google-automation-mcp" / "routers"
+TEMPLATE_DIR = Path(__file__).parent
+
+
+def _state_path(user_email: str) -> Path:
+    safe = user_email.replace("@", "_at_").replace(".", "_")
+    return ROUTER_STATE_DIR / f"{safe}.json"
+
+
+def _load_state(user_email: str) -> Optional[Dict[str, Any]]:
+    path = _state_path(user_email)
+    if not path.exists():
+        return None
+    return json.loads(path.read_text())
+
+
+def _save_state(user_email: str, state: Dict[str, Any]) -> None:
+    ROUTER_STATE_DIR.mkdir(parents=True, exist_ok=True)
+    path = _state_path(user_email)
+    path.write_text(json.dumps(state, indent=2))
+    os.chmod(path, 0o600)
+
+
+def _get_script_source(secret: str) -> str:
+    template = (TEMPLATE_DIR / "script_template.js").read_text()
+    return template.replace("{{MCP_SECRET}}", secret)
+
+
+def _get_manifest() -> str:
+    return (TEMPLATE_DIR / "manifest.json").read_text()
+
+
+async def _create_script_project(title: str) -> str:
+    service = get_script_service()
+    body = {"title": title}
+    try:
+        project = await asyncio.to_thread(
+            service.projects().create(body=body).execute
+        )
+    except HttpError as e:
+        if "User has not enabled the Apps Script API" in str(e):
+            raise RuntimeError(
+                "Apps Script API is not enabled. "
+                "Enable it at https://script.google.com/home/usersettings "
+                "then retry."
+            ) from None
+        raise
+    return project["scriptId"]
+
+
+async def _upload_script_content(script_id: str, secret: str) -> None:
+    service = get_script_service()
+    body = {
+        "files": [
+            {
+                "name": "Router",
+                "type": "SERVER_JS",
+                "source": _get_script_source(secret),
+            },
+            {
+                "name": "appsscript",
+                "type": "JSON",
+                "source": _get_manifest(),
+            },
+        ]
+    }
+    await asyncio.to_thread(
+        service.projects().updateContent(
+            scriptId=script_id, body=body
+        ).execute
+    )
+
+
+async def _create_version(script_id: str, description: str) -> int:
+    service = get_script_service()
+    body = {"description": description}
+    version = await asyncio.to_thread(
+        service.projects().versions().create(
+            scriptId=script_id, body=body
+        ).execute
+    )
+    return version["versionNumber"]
+
+
+async def _create_web_app_deployment(script_id: str, version_number: int) -> str:
+    service = get_script_service()
+    body = {
+        "versionNumber": version_number,
+        "description": "MCP Router",
+        "manifestFileName": "appsscript",
+    }
+    deployment = await asyncio.to_thread(
+        service.projects().deployments().create(
+            scriptId=script_id, body=body
+        ).execute
+    )
+    deployment_id = deployment["deploymentId"]
+    web_app_url = f"https://script.google.com/macros/s/{deployment_id}/exec"
+    return web_app_url
+
+
+async def _update_deployment(
+    script_id: str, deployment_id: str, version_number: int
+) -> str:
+    service = get_script_service()
+    body = {
+        "deploymentConfig": {
+            "versionNumber": version_number,
+            "description": "MCP Router",
+            "manifestFileName": "appsscript",
+        }
+    }
+    await asyncio.to_thread(
+        service.projects().deployments().update(
+            scriptId=script_id, deploymentId=deployment_id, body=body
+        ).execute
+    )
+    web_app_url = f"https://script.google.com/macros/s/{deployment_id}/exec"
+    return web_app_url
+
+
+async def deploy_router(user_email: str) -> Dict[str, Any]:
+    """
+    Deploy a fresh router for a user. Returns state dict with
+    script_id, deployment_id, web_app_url, and secret.
+    """
+    secret = secrets.token_urlsafe(32)
+    title = "MCP-Router"
+
+    logger.info(f"Creating router script for {user_email}")
+    script_id = await _create_script_project(title)
+
+    logger.info(f"Uploading router code to {script_id}")
+    await _upload_script_content(script_id, secret)
+
+    logger.info(f"Creating version for {script_id}")
+    version = await _create_version(script_id, "MCP Router v1")
+
+    logger.info(f"Deploying web app for {script_id} v{version}")
+    web_app_url = await _create_web_app_deployment(script_id, version)
+
+    state = {
+        "user_email": user_email,
+        "script_id": script_id,
+        "version": version,
+        "web_app_url": web_app_url,
+        "secret": secret,
+    }
+    _save_state(user_email, state)
+
+    logger.info(f"Router deployed: {web_app_url}")
+    return state
+
+
+async def update_router(user_email: str) -> Dict[str, Any]:
+    """
+    Update an existing router's code and redeploy.
+    """
+    state = _load_state(user_email)
+    if not state:
+        return await deploy_router(user_email)
+
+    script_id = state["script_id"]
+    secret = state["secret"]
+
+    logger.info(f"Updating router code for {script_id}")
+    await _upload_script_content(script_id, secret)
+
+    version = await _create_version(script_id, "MCP Router update")
+
+    # Find existing deployment to update
+    service = get_script_service()
+    deployments = await asyncio.to_thread(
+        service.projects().deployments().list(scriptId=script_id).execute
+    )
+    deployment_list = deployments.get("deployments", [])
+
+    # Find the non-HEAD deployment
+    deployment_id = None
+    for d in deployment_list:
+        config = d.get("deploymentConfig", {})
+        if config.get("description") == "MCP Router":
+            deployment_id = d["deploymentId"]
+            break
+
+    if deployment_id:
+        web_app_url = await _update_deployment(script_id, deployment_id, version)
+    else:
+        web_app_url = await _create_web_app_deployment(script_id, version)
+
+    state["version"] = version
+    state["web_app_url"] = web_app_url
+    _save_state(user_email, state)
+
+    logger.info(f"Router updated: {web_app_url}")
+    return state
+
+
+async def ensure_router_deployed(user_email: str) -> Dict[str, Any]:
+    """
+    Ensure a router is deployed for the user. Returns state dict.
+    Creates one if it doesn't exist.
+    """
+    state = _load_state(user_email)
+    if state and state.get("web_app_url"):
+        return state
+    return await deploy_router(user_email)

--- a/src/google_automation_mcp/router/manifest.json
+++ b/src/google_automation_mcp/router/manifest.json
@@ -1,6 +1,14 @@
 {
   "timeZone": "America/Los_Angeles",
-  "dependencies": {},
+  "dependencies": {
+    "enabledAdvancedServices": [
+      {
+        "userSymbol": "Drive",
+        "version": "v3",
+        "serviceId": "drive"
+      }
+    ]
+  },
   "exceptionLogging": "STACKDRIVER",
   "runtimeVersion": "V8",
   "webapp": {
@@ -11,6 +19,15 @@
     "https://mail.google.com/",
     "https://www.googleapis.com/auth/gmail.modify",
     "https://www.googleapis.com/auth/gmail.send",
-    "https://www.googleapis.com/auth/gmail.labels"
+    "https://www.googleapis.com/auth/gmail.labels",
+    "https://www.googleapis.com/auth/drive",
+    "https://www.googleapis.com/auth/spreadsheets",
+    "https://www.googleapis.com/auth/calendar",
+    "https://www.googleapis.com/auth/documents",
+    "https://www.googleapis.com/auth/forms",
+    "https://www.googleapis.com/auth/forms.body",
+    "https://www.googleapis.com/auth/forms.responses.readonly",
+    "https://www.googleapis.com/auth/tasks",
+    "https://www.googleapis.com/auth/script.external_request"
   ]
 }

--- a/src/google_automation_mcp/router/manifest.json
+++ b/src/google_automation_mcp/router/manifest.json
@@ -1,0 +1,16 @@
+{
+  "timeZone": "America/Los_Angeles",
+  "dependencies": {},
+  "exceptionLogging": "STACKDRIVER",
+  "runtimeVersion": "V8",
+  "webapp": {
+    "executeAs": "USER_DEPLOYING",
+    "access": "ANYONE_ANONYMOUS"
+  },
+  "oauthScopes": [
+    "https://mail.google.com/",
+    "https://www.googleapis.com/auth/gmail.modify",
+    "https://www.googleapis.com/auth/gmail.send",
+    "https://www.googleapis.com/auth/gmail.labels"
+  ]
+}

--- a/src/google_automation_mcp/router/script_template.js
+++ b/src/google_automation_mcp/router/script_template.js
@@ -4,6 +4,16 @@
 
 var SECRET = '{{MCP_SECRET}}';
 
+function doGet() {
+  // Touching GmailApp triggers the OAuth consent for Gmail scopes.
+  // After the user authorizes, all doPost calls work from the server.
+  GmailApp.getAliases();
+  return HtmlService.createHtmlOutput(
+    '<h2>MCP Router authorized</h2>' +
+    '<p>Gmail access granted. You can close this tab.</p>'
+  );
+}
+
 function doPost(e) {
   var payload = JSON.parse(e.postData.contents);
   if (payload.secret !== SECRET) {

--- a/src/google_automation_mcp/router/script_template.js
+++ b/src/google_automation_mcp/router/script_template.js
@@ -1,0 +1,169 @@
+// Google Automation MCP — Apps Script Router
+// Deployed as a Web App. Called via HTTP POST from the MCP server.
+// Each request must include a secret token for authentication.
+
+var SECRET = '{{MCP_SECRET}}';
+
+function doPost(e) {
+  var payload = JSON.parse(e.postData.contents);
+  if (payload.secret !== SECRET) {
+    return _json({error: 'unauthorized', code: 403});
+  }
+  var handler = ROUTES[payload.action];
+  if (!handler) {
+    return _json({error: 'unknown action: ' + payload.action, code: 400});
+  }
+  try {
+    var result = handler(payload.params || {});
+    return _json({result: result});
+  } catch (err) {
+    return _json({error: err.message, stack: err.stack, code: 500});
+  }
+}
+
+function _json(obj) {
+  return ContentService.createTextOutput(JSON.stringify(obj))
+    .setMimeType(ContentService.MimeType.JSON);
+}
+
+// =============================================================================
+// Route Table
+// =============================================================================
+
+var ROUTES = {
+  'search_gmail': searchGmail,
+  'get_gmail_message': getGmailMessage,
+  'send_gmail': sendGmail,
+  'list_gmail_labels': listGmailLabels,
+  'modify_gmail_labels': modifyGmailLabels
+};
+
+// =============================================================================
+// Gmail Handlers
+// =============================================================================
+
+function searchGmail(p) {
+  var query = p.query || '';
+  var maxResults = p.max_results || 10;
+  var threads = GmailApp.search(query, 0, maxResults);
+  var results = [];
+  for (var i = 0; i < threads.length; i++) {
+    var thread = threads[i];
+    var msgs = thread.getMessages();
+    var first = msgs[0];
+    var labels = thread.getLabels();
+    var labelNames = [];
+    for (var j = 0; j < labels.length; j++) {
+      labelNames.push(labels[j].getName());
+    }
+    results.push({
+      id: thread.getId(),
+      message_id: first.getId(),
+      subject: first.getSubject(),
+      from: first.getFrom(),
+      to: first.getTo(),
+      date: first.getDate().toISOString(),
+      snippet: first.getPlainBody().substring(0, 200),
+      labels: labelNames,
+      unread: thread.isUnread(),
+      message_count: msgs.length
+    });
+  }
+  return results;
+}
+
+function getGmailMessage(p) {
+  var msg = GmailApp.getMessageById(p.message_id);
+  if (!msg) {
+    throw new Error('Message not found: ' + p.message_id);
+  }
+  var attachments = msg.getAttachments();
+  var attachmentInfo = [];
+  for (var i = 0; i < attachments.length; i++) {
+    attachmentInfo.push({
+      name: attachments[i].getName(),
+      type: attachments[i].getContentType(),
+      size: attachments[i].getSize()
+    });
+  }
+  return {
+    id: msg.getId(),
+    thread_id: msg.getThread().getId(),
+    subject: msg.getSubject(),
+    from: msg.getFrom(),
+    to: msg.getTo(),
+    cc: msg.getCc(),
+    bcc: msg.getBcc(),
+    date: msg.getDate().toISOString(),
+    body: msg.getPlainBody().substring(0, 5000),
+    is_html: msg.getBody() !== msg.getPlainBody(),
+    starred: msg.isStarred(),
+    unread: msg.isUnread(),
+    attachments: attachmentInfo
+  };
+}
+
+function sendGmail(p) {
+  var options = {};
+  if (p.cc) options.cc = p.cc;
+  if (p.bcc) options.bcc = p.bcc;
+  if (p.html) {
+    options.htmlBody = p.body;
+    GmailApp.sendEmail(p.to, p.subject, '', options);
+  } else {
+    GmailApp.sendEmail(p.to, p.subject, p.body, options);
+  }
+  return {sent: true, to: p.to, subject: p.subject};
+}
+
+function listGmailLabels(p) {
+  var labels = GmailApp.getUserLabels();
+  var userLabels = [];
+  for (var i = 0; i < labels.length; i++) {
+    userLabels.push({name: labels[i].getName()});
+  }
+  // System labels are not accessible via GmailApp, note that
+  return {
+    user_labels: userLabels,
+    note: 'System labels (INBOX, SENT, etc.) are not available via Apps Script GmailApp'
+  };
+}
+
+function modifyGmailLabels(p) {
+  var msg = GmailApp.getMessageById(p.message_id);
+  if (!msg) {
+    throw new Error('Message not found: ' + p.message_id);
+  }
+  var thread = msg.getThread();
+  var added = [];
+  var removed = [];
+
+  if (p.add_labels) {
+    for (var i = 0; i < p.add_labels.length; i++) {
+      var labelName = p.add_labels[i];
+      // Handle system-like actions
+      if (labelName === 'STARRED') { msg.star(); added.push('STARRED'); continue; }
+      if (labelName === 'UNREAD') { msg.markUnread(); added.push('UNREAD'); continue; }
+      if (labelName === 'TRASH') { msg.moveToTrash(); added.push('TRASH'); continue; }
+      if (labelName === 'INBOX') { msg.getThread().moveToInbox(); added.push('INBOX'); continue; }
+      // User label
+      var label = GmailApp.getUserLabelByName(labelName);
+      if (!label) label = GmailApp.createLabel(labelName);
+      thread.addLabel(label);
+      added.push(labelName);
+    }
+  }
+
+  if (p.remove_labels) {
+    for (var j = 0; j < p.remove_labels.length; j++) {
+      var rlabelName = p.remove_labels[j];
+      if (rlabelName === 'STARRED') { msg.unstar(); removed.push('STARRED'); continue; }
+      if (rlabelName === 'UNREAD') { msg.markRead(); removed.push('UNREAD'); continue; }
+      if (rlabelName === 'INBOX') { thread.moveToArchive(); removed.push('INBOX'); continue; }
+      var rlabel = GmailApp.getUserLabelByName(rlabelName);
+      if (rlabel) { thread.removeLabel(rlabel); removed.push(rlabelName); }
+    }
+  }
+
+  return {message_id: p.message_id, added: added, removed: removed};
+}

--- a/src/google_automation_mcp/router/script_template.js
+++ b/src/google_automation_mcp/router/script_template.js
@@ -5,12 +5,14 @@
 var SECRET = '{{MCP_SECRET}}';
 
 function doGet() {
-  // Touching GmailApp triggers the OAuth consent for Gmail scopes.
-  // After the user authorizes, all doPost calls work from the server.
-  GmailApp.getAliases();
+  // Touch services that require explicit scope activation.
+  // Without these calls, manifest-only scopes may not trigger consent.
+  try { UrlFetchApp.fetch('https://www.googleapis.com/tasks/v1/users/@me/lists?maxResults=1', {
+    headers: {'Authorization': 'Bearer ' + ScriptApp.getOAuthToken()}, muteHttpExceptions: true
+  }); } catch(e) {}
   return HtmlService.createHtmlOutput(
     '<h2>MCP Router authorized</h2>' +
-    '<p>Gmail access granted. You can close this tab.</p>'
+    '<p>All Google Workspace scopes granted. You can close this tab.</p>'
   );
 }
 
@@ -41,11 +43,54 @@ function _json(obj) {
 // =============================================================================
 
 var ROUTES = {
+  // Gmail
   'search_gmail': searchGmail,
   'get_gmail_message': getGmailMessage,
   'send_gmail': sendGmail,
   'list_gmail_labels': listGmailLabels,
-  'modify_gmail_labels': modifyGmailLabels
+  'modify_gmail_labels': modifyGmailLabels,
+  // Drive
+  'search_drive': searchDrive,
+  'list_drive': listDrive,
+  'get_drive_content': getDriveContent,
+  'create_drive_file': createDriveFile,
+  'create_drive_folder': createDriveFolder,
+  'delete_drive_file': deleteDriveFile,
+  'trash_drive_file': trashDriveFile,
+  'share_drive_file': shareDriveFile,
+  'list_drive_permissions': listDrivePermissions,
+  'remove_drive_permission': removeDrivePermission,
+  // Sheets
+  'list_spreadsheets': listSpreadsheets,
+  'get_sheet_values': getSheetValues,
+  'update_sheet_values': updateSheetValues,
+  'append_sheet_values': appendSheetValues,
+  'create_spreadsheet': createSpreadsheet,
+  'get_spreadsheet_metadata': getSpreadsheetMetadata,
+  // Calendar
+  'list_calendars': listCalendars,
+  'get_events': getEvents,
+  'create_event': createEvent,
+  'update_event': updateEvent,
+  'delete_event': deleteEvent,
+  // Docs
+  'search_docs': searchDocs,
+  'get_doc_content': getDocContent,
+  'create_doc': createDoc,
+  'modify_doc_text': modifyDocText,
+  'append_doc_text': appendDocText,
+  // Forms
+  'get_form': getForm,
+  'create_form': createForm,
+  'add_form_question': addFormQuestion,
+  'get_form_responses': getFormResponses,
+  // Tasks
+  'list_task_lists': listTaskLists,
+  'get_tasks': getTasks,
+  'create_task': createTask,
+  'update_task': updateTask,
+  'delete_task': deleteTask,
+  'complete_task': completeTask
 };
 
 // =============================================================================
@@ -84,9 +129,7 @@ function searchGmail(p) {
 
 function getGmailMessage(p) {
   var msg = GmailApp.getMessageById(p.message_id);
-  if (!msg) {
-    throw new Error('Message not found: ' + p.message_id);
-  }
+  if (!msg) throw new Error('Message not found: ' + p.message_id);
   var attachments = msg.getAttachments();
   var attachmentInfo = [];
   for (var i = 0; i < attachments.length; i++) {
@@ -97,18 +140,13 @@ function getGmailMessage(p) {
     });
   }
   return {
-    id: msg.getId(),
-    thread_id: msg.getThread().getId(),
-    subject: msg.getSubject(),
-    from: msg.getFrom(),
-    to: msg.getTo(),
-    cc: msg.getCc(),
-    bcc: msg.getBcc(),
+    id: msg.getId(), thread_id: msg.getThread().getId(),
+    subject: msg.getSubject(), from: msg.getFrom(), to: msg.getTo(),
+    cc: msg.getCc(), bcc: msg.getBcc(),
     date: msg.getDate().toISOString(),
     body: msg.getPlainBody().substring(0, 5000),
     is_html: msg.getBody() !== msg.getPlainBody(),
-    starred: msg.isStarred(),
-    unread: msg.isUnread(),
+    starred: msg.isStarred(), unread: msg.isUnread(),
     attachments: attachmentInfo
   };
 }
@@ -132,7 +170,6 @@ function listGmailLabels(p) {
   for (var i = 0; i < labels.length; i++) {
     userLabels.push({name: labels[i].getName()});
   }
-  // System labels are not accessible via GmailApp, note that
   return {
     user_labels: userLabels,
     note: 'System labels (INBOX, SENT, etc.) are not available via Apps Script GmailApp'
@@ -141,39 +178,546 @@ function listGmailLabels(p) {
 
 function modifyGmailLabels(p) {
   var msg = GmailApp.getMessageById(p.message_id);
-  if (!msg) {
-    throw new Error('Message not found: ' + p.message_id);
-  }
+  if (!msg) throw new Error('Message not found: ' + p.message_id);
   var thread = msg.getThread();
-  var added = [];
-  var removed = [];
-
+  var added = [], removed = [];
   if (p.add_labels) {
     for (var i = 0; i < p.add_labels.length; i++) {
-      var labelName = p.add_labels[i];
-      // Handle system-like actions
-      if (labelName === 'STARRED') { msg.star(); added.push('STARRED'); continue; }
-      if (labelName === 'UNREAD') { msg.markUnread(); added.push('UNREAD'); continue; }
-      if (labelName === 'TRASH') { msg.moveToTrash(); added.push('TRASH'); continue; }
-      if (labelName === 'INBOX') { msg.getThread().moveToInbox(); added.push('INBOX'); continue; }
-      // User label
-      var label = GmailApp.getUserLabelByName(labelName);
-      if (!label) label = GmailApp.createLabel(labelName);
+      var ln = p.add_labels[i];
+      if (ln === 'STARRED') { msg.star(); added.push(ln); continue; }
+      if (ln === 'UNREAD') { msg.markUnread(); added.push(ln); continue; }
+      if (ln === 'TRASH') { msg.moveToTrash(); added.push(ln); continue; }
+      if (ln === 'INBOX') { thread.moveToInbox(); added.push(ln); continue; }
+      var label = GmailApp.getUserLabelByName(ln);
+      if (!label) label = GmailApp.createLabel(ln);
       thread.addLabel(label);
-      added.push(labelName);
+      added.push(ln);
     }
   }
-
   if (p.remove_labels) {
     for (var j = 0; j < p.remove_labels.length; j++) {
-      var rlabelName = p.remove_labels[j];
-      if (rlabelName === 'STARRED') { msg.unstar(); removed.push('STARRED'); continue; }
-      if (rlabelName === 'UNREAD') { msg.markRead(); removed.push('UNREAD'); continue; }
-      if (rlabelName === 'INBOX') { thread.moveToArchive(); removed.push('INBOX'); continue; }
-      var rlabel = GmailApp.getUserLabelByName(rlabelName);
-      if (rlabel) { thread.removeLabel(rlabel); removed.push(rlabelName); }
+      var rn = p.remove_labels[j];
+      if (rn === 'STARRED') { msg.unstar(); removed.push(rn); continue; }
+      if (rn === 'UNREAD') { msg.markRead(); removed.push(rn); continue; }
+      if (rn === 'INBOX') { thread.moveToArchive(); removed.push(rn); continue; }
+      var rl = GmailApp.getUserLabelByName(rn);
+      if (rl) { thread.removeLabel(rl); removed.push(rn); }
     }
   }
-
   return {message_id: p.message_id, added: added, removed: removed};
+}
+
+// =============================================================================
+// Drive Handlers
+// =============================================================================
+
+function searchDrive(p) {
+  var query = p.query || '';
+  var maxResults = p.page_size || 10;
+  var files, iter;
+  if (query.indexOf('contains') >= 0 || query.indexOf('=') >= 0) {
+    iter = DriveApp.searchFiles(query);
+  } else {
+    iter = DriveApp.searchFiles("fullText contains '" + query.replace(/'/g, "\\'") + "'");
+  }
+  var results = [];
+  while (iter.hasNext() && results.length < maxResults) {
+    var f = iter.next();
+    results.push({
+      id: f.getId(), name: f.getName(), mime_type: f.getMimeType(),
+      size: f.getSize(), modified: f.getLastUpdated().toISOString(),
+      url: f.getUrl()
+    });
+  }
+  return results;
+}
+
+function listDrive(p) {
+  var folderId = p.folder_id || 'root';
+  var maxResults = p.page_size || 50;
+  var folder = (folderId === 'root') ? DriveApp.getRootFolder() : DriveApp.getFolderById(folderId);
+  var results = {folders: [], files: []};
+  var folders = folder.getFolders();
+  while (folders.hasNext() && results.folders.length < maxResults) {
+    var fo = folders.next();
+    results.folders.push({id: fo.getId(), name: fo.getName()});
+  }
+  var files = folder.getFiles();
+  while (files.hasNext() && results.files.length < maxResults) {
+    var fi = files.next();
+    results.files.push({
+      id: fi.getId(), name: fi.getName(), mime_type: fi.getMimeType(),
+      size: fi.getSize()
+    });
+  }
+  return results;
+}
+
+function getDriveContent(p) {
+  var file = DriveApp.getFileById(p.file_id);
+  var mime = file.getMimeType();
+  var content;
+  if (mime === 'application/vnd.google-apps.document') {
+    var doc = DocumentApp.openById(p.file_id);
+    content = doc.getBody().getText();
+  } else if (mime === 'application/vnd.google-apps.spreadsheet') {
+    var ss = SpreadsheetApp.openById(p.file_id);
+    var sheet = ss.getActiveSheet();
+    var data = sheet.getDataRange().getValues();
+    content = data.map(function(row) { return row.join(','); }).join('\n');
+  } else {
+    content = file.getBlob().getDataAsString();
+  }
+  return {
+    id: file.getId(), name: file.getName(), mime_type: mime,
+    url: file.getUrl(), content: content.substring(0, 50000)
+  };
+}
+
+function createDriveFile(p) {
+  var folder = (p.folder_id && p.folder_id !== 'root')
+    ? DriveApp.getFolderById(p.folder_id) : DriveApp.getRootFolder();
+  var blob = Utilities.newBlob(p.content || '', p.mime_type || 'text/plain', p.file_name);
+  var file = folder.createFile(blob);
+  return {id: file.getId(), name: file.getName(), url: file.getUrl()};
+}
+
+function createDriveFolder(p) {
+  var parent = (p.parent_id && p.parent_id !== 'root')
+    ? DriveApp.getFolderById(p.parent_id) : DriveApp.getRootFolder();
+  var folder = parent.createFolder(p.folder_name);
+  return {id: folder.getId(), name: folder.getName(), url: folder.getUrl()};
+}
+
+function deleteDriveFile(p) {
+  DriveApp.getFileById(p.file_id).setTrashed(true);
+  Drive.Files.remove(p.file_id);
+  return {deleted: true, file_id: p.file_id};
+}
+
+function trashDriveFile(p) {
+  DriveApp.getFileById(p.file_id).setTrashed(true);
+  return {trashed: true, file_id: p.file_id};
+}
+
+function shareDriveFile(p) {
+  var file = DriveApp.getFileById(p.file_id);
+  var role = p.role || 'reader';
+  if (role === 'writer' || role === 'owner') {
+    file.addEditor(p.email);
+  } else if (role === 'commenter') {
+    file.addCommenter(p.email);
+  } else {
+    file.addViewer(p.email);
+  }
+  return {shared: true, file_id: p.file_id, email: p.email, role: role};
+}
+
+function listDrivePermissions(p) {
+  var file = DriveApp.getFileById(p.file_id);
+  var editors = file.getEditors().map(function(u) {
+    return {email: u.getEmail(), role: 'writer'};
+  });
+  var viewers = file.getViewers().map(function(u) {
+    return {email: u.getEmail(), role: 'reader'};
+  });
+  return {file_id: p.file_id, permissions: editors.concat(viewers)};
+}
+
+function removeDrivePermission(p) {
+  var file = DriveApp.getFileById(p.file_id);
+  file.removeEditor(p.permission_id);
+  file.removeViewer(p.permission_id);
+  return {removed: true, file_id: p.file_id, permission_id: p.permission_id};
+}
+
+// =============================================================================
+// Sheets Handlers
+// =============================================================================
+
+function listSpreadsheets(p) {
+  var query = "mimeType='application/vnd.google-apps.spreadsheet' and trashed=false";
+  if (p.query) query += " and name contains '" + p.query.replace(/'/g, "\\'") + "'";
+  var iter = DriveApp.searchFiles(query);
+  var results = [];
+  var max = p.page_size || 20;
+  while (iter.hasNext() && results.length < max) {
+    var f = iter.next();
+    results.push({
+      id: f.getId(), name: f.getName(),
+      modified: f.getLastUpdated().toISOString(), url: f.getUrl()
+    });
+  }
+  return results;
+}
+
+function getSheetValues(p) {
+  var ss = SpreadsheetApp.openById(p.spreadsheet_id);
+  var range = p.range || 'Sheet1';
+  var sheet, dataRange;
+  if (range.indexOf('!') >= 0) {
+    var parts = range.split('!');
+    sheet = ss.getSheetByName(parts[0]);
+    dataRange = sheet.getRange(parts[1]);
+  } else {
+    sheet = ss.getSheetByName(range) || ss.getSheets()[0];
+    dataRange = sheet.getDataRange();
+  }
+  return {
+    spreadsheet_id: p.spreadsheet_id, range: range,
+    values: dataRange.getValues()
+  };
+}
+
+function updateSheetValues(p) {
+  var ss = SpreadsheetApp.openById(p.spreadsheet_id);
+  var parts = p.range.split('!');
+  var sheet = (parts.length > 1) ? ss.getSheetByName(parts[0]) : ss.getSheets()[0];
+  var rangeStr = (parts.length > 1) ? parts[1] : parts[0];
+  var range = sheet.getRange(rangeStr);
+  range.setValues(p.values);
+  return {
+    spreadsheet_id: p.spreadsheet_id, range: p.range,
+    updated_rows: p.values.length, updated_cells: p.values.length * p.values[0].length
+  };
+}
+
+function appendSheetValues(p) {
+  var ss = SpreadsheetApp.openById(p.spreadsheet_id);
+  var sheetName = p.range ? p.range.split('!')[0] : null;
+  var sheet = sheetName ? (ss.getSheetByName(sheetName) || ss.getSheets()[0]) : ss.getSheets()[0];
+  var lastRow = sheet.getLastRow();
+  var startRow = lastRow + 1;
+  var range = sheet.getRange(startRow, 1, p.values.length, p.values[0].length);
+  range.setValues(p.values);
+  return {
+    spreadsheet_id: p.spreadsheet_id,
+    updated_range: sheet.getName() + '!A' + startRow,
+    updated_rows: p.values.length, updated_cells: p.values.length * p.values[0].length
+  };
+}
+
+function createSpreadsheet(p) {
+  var ss = SpreadsheetApp.create(p.title);
+  var sheets = [];
+  if (p.sheet_names && p.sheet_names.length > 0) {
+    var first = ss.getSheets()[0];
+    first.setName(p.sheet_names[0]);
+    sheets.push(p.sheet_names[0]);
+    for (var i = 1; i < p.sheet_names.length; i++) {
+      ss.insertSheet(p.sheet_names[i]);
+      sheets.push(p.sheet_names[i]);
+    }
+  } else {
+    sheets.push(ss.getSheets()[0].getName());
+  }
+  return {
+    spreadsheet_id: ss.getId(), title: p.title,
+    sheets: sheets, url: ss.getUrl()
+  };
+}
+
+function getSpreadsheetMetadata(p) {
+  var ss = SpreadsheetApp.openById(p.spreadsheet_id);
+  var sheets = ss.getSheets().map(function(s) {
+    return {
+      title: s.getName(), sheet_id: s.getSheetId(),
+      rows: s.getMaxRows(), cols: s.getMaxColumns()
+    };
+  });
+  return {
+    spreadsheet_id: p.spreadsheet_id, title: ss.getName(),
+    sheets: sheets, url: ss.getUrl()
+  };
+}
+
+// =============================================================================
+// Calendar Handlers
+// =============================================================================
+
+function listCalendars(p) {
+  var cals = CalendarApp.getAllCalendars();
+  return cals.map(function(c) {
+    return {
+      id: c.getId(), name: c.getName(),
+      is_primary: c.isMyPrimaryCalendar()
+    };
+  });
+}
+
+function getEvents(p) {
+  var calId = p.calendar_id || 'primary';
+  var cal = (calId === 'primary') ? CalendarApp.getDefaultCalendar() : CalendarApp.getCalendarById(calId);
+  if (!cal) throw new Error('Calendar not found: ' + calId);
+  var now = new Date();
+  var start = p.time_min ? new Date(p.time_min) : now;
+  var end = p.time_max ? new Date(p.time_max) : new Date(now.getTime() + 7*24*60*60*1000);
+  var events = cal.getEvents(start, end);
+  if (p.query) {
+    var q = p.query.toLowerCase();
+    events = events.filter(function(e) {
+      return e.getTitle().toLowerCase().indexOf(q) >= 0;
+    });
+  }
+  var max = p.max_results || 10;
+  return events.slice(0, max).map(function(e) {
+    return {
+      id: e.getId(), summary: e.getTitle(),
+      start: e.getStartTime().toISOString(), end: e.getEndTime().toISOString(),
+      location: e.getLocation(), description: e.getDescription(),
+      all_day: e.isAllDayEvent()
+    };
+  });
+}
+
+function createEvent(p) {
+  var calId = p.calendar_id || 'primary';
+  var cal = (calId === 'primary') ? CalendarApp.getDefaultCalendar() : CalendarApp.getCalendarById(calId);
+  if (!cal) throw new Error('Calendar not found: ' + calId);
+  var ev;
+  var options = {};
+  if (p.description) options.description = p.description;
+  if (p.location) options.location = p.location;
+  if (p.all_day) {
+    ev = cal.createAllDayEvent(p.summary, new Date(p.start_time), new Date(p.end_time), options);
+  } else {
+    ev = cal.createEvent(p.summary, new Date(p.start_time), new Date(p.end_time), options);
+  }
+  if (p.attendees) {
+    var emails = p.attendees.split(',');
+    for (var i = 0; i < emails.length; i++) ev.addGuest(emails[i].trim());
+  }
+  return {
+    id: ev.getId(), summary: ev.getTitle(),
+    start: ev.getStartTime().toISOString(), calendar_id: calId
+  };
+}
+
+function updateEvent(p) {
+  var calId = p.calendar_id || 'primary';
+  var cal = (calId === 'primary') ? CalendarApp.getDefaultCalendar() : CalendarApp.getCalendarById(calId);
+  if (!cal) throw new Error('Calendar not found: ' + calId);
+  var ev = cal.getEventById(p.event_id);
+  if (!ev) throw new Error('Event not found: ' + p.event_id);
+  if (p.summary !== undefined) ev.setTitle(p.summary);
+  if (p.description !== undefined) ev.setDescription(p.description);
+  if (p.location !== undefined) ev.setLocation(p.location);
+  if (p.start_time && p.end_time) ev.setTime(new Date(p.start_time), new Date(p.end_time));
+  return {
+    id: ev.getId(), summary: ev.getTitle(),
+    start: ev.getStartTime().toISOString(), calendar_id: calId
+  };
+}
+
+function deleteEvent(p) {
+  var calId = p.calendar_id || 'primary';
+  var cal = (calId === 'primary') ? CalendarApp.getDefaultCalendar() : CalendarApp.getCalendarById(calId);
+  if (!cal) throw new Error('Calendar not found: ' + calId);
+  var ev = cal.getEventById(p.event_id);
+  if (!ev) throw new Error('Event not found: ' + p.event_id);
+  ev.deleteEvent();
+  return {deleted: true, event_id: p.event_id, calendar_id: calId};
+}
+
+// =============================================================================
+// Docs Handlers
+// =============================================================================
+
+function searchDocs(p) {
+  var q = (p.query || '').replace(/'/g, "\\'");
+  var query = "mimeType = 'application/vnd.google-apps.document' and trashed = false and title contains '" + q + "'";
+  var iter = DriveApp.searchFiles(query);
+  var results = [];
+  var max = p.page_size || 10;
+  while (iter.hasNext() && results.length < max) {
+    var f = iter.next();
+    results.push({
+      id: f.getId(), name: f.getName(),
+      modified: f.getLastUpdated().toISOString(), url: f.getUrl()
+    });
+  }
+  return results;
+}
+
+function getDocContent(p) {
+  var doc = DocumentApp.openById(p.document_id);
+  return {
+    document_id: p.document_id, title: doc.getName(),
+    content: doc.getBody().getText(),
+    url: doc.getUrl()
+  };
+}
+
+function createDoc(p) {
+  var doc = DocumentApp.create(p.title);
+  if (p.content) doc.getBody().setText(p.content);
+  return {document_id: doc.getId(), title: doc.getName(), url: doc.getUrl()};
+}
+
+function modifyDocText(p) {
+  var doc = DocumentApp.openById(p.document_id);
+  var body = doc.getBody();
+  if (p.replace_text) {
+    body.replaceText(p.replace_text, p.text);
+    return {document_id: p.document_id, action: 'replace', url: doc.getUrl()};
+  } else {
+    var index = p.index || 0;
+    if (index <= 0) {
+      body.insertParagraph(0, p.text);
+    } else {
+      body.insertParagraph(index, p.text);
+    }
+    return {document_id: p.document_id, action: 'insert', index: index, url: doc.getUrl()};
+  }
+}
+
+function appendDocText(p) {
+  var doc = DocumentApp.openById(p.document_id);
+  doc.getBody().appendParagraph(p.text);
+  return {document_id: p.document_id, url: doc.getUrl()};
+}
+
+// =============================================================================
+// Forms Handlers
+// =============================================================================
+
+function getForm(p) {
+  var form = FormApp.openById(p.form_id);
+  var items = form.getItems().map(function(item, idx) {
+    return {
+      index: idx + 1, title: item.getTitle(),
+      item_id: item.getId(), type: item.getType().toString()
+    };
+  });
+  return {
+    form_id: form.getId(), title: form.getTitle(),
+    description: form.getDescription(),
+    url: form.getPublishedUrl(), edit_url: form.getEditUrl(),
+    items: items
+  };
+}
+
+function createForm(p) {
+  var form = FormApp.create(p.title);
+  if (p.description) form.setDescription(p.description);
+  return {
+    form_id: form.getId(), title: form.getTitle(),
+    url: form.getPublishedUrl(), edit_url: form.getEditUrl()
+  };
+}
+
+function addFormQuestion(p) {
+  var form = FormApp.openById(p.form_id);
+  var item;
+  var type = (p.question_type || 'TEXT').toUpperCase();
+  if (type === 'MULTIPLE_CHOICE') {
+    item = form.addMultipleChoiceItem().setTitle(p.title);
+    if (p.choices) item.setChoiceValues(p.choices.split(',').map(function(c) { return c.trim(); }));
+  } else if (type === 'CHECKBOX') {
+    item = form.addCheckboxItem().setTitle(p.title);
+    if (p.choices) item.setChoiceValues(p.choices.split(',').map(function(c) { return c.trim(); }));
+  } else if (type === 'DROP_DOWN') {
+    item = form.addListItem().setTitle(p.title);
+    if (p.choices) item.setChoiceValues(p.choices.split(',').map(function(c) { return c.trim(); }));
+  } else if (type === 'PARAGRAPH') {
+    item = form.addParagraphTextItem().setTitle(p.title);
+  } else if (type === 'SCALE') {
+    item = form.addScaleItem().setTitle(p.title).setBounds(1, 5);
+  } else {
+    item = form.addTextItem().setTitle(p.title);
+  }
+  if (p.required && item.setRequired) item.setRequired(true);
+  return {form_id: p.form_id, title: p.title, type: type};
+}
+
+function getFormResponses(p) {
+  var form = FormApp.openById(p.form_id);
+  var responses = form.getResponses();
+  var max = p.max_results || 50;
+  var results = [];
+  var start = Math.max(0, responses.length - max);
+  for (var i = start; i < responses.length; i++) {
+    var r = responses[i];
+    var answers = r.getItemResponses().map(function(ir) {
+      return {question: ir.getItem().getTitle(), answer: ir.getResponse()};
+    });
+    results.push({
+      response_id: r.getId(), timestamp: r.getTimestamp().toISOString(),
+      answers: answers
+    });
+  }
+  return results;
+}
+
+// =============================================================================
+// Tasks Handlers (via REST API + UrlFetchApp, no advanced service needed)
+// =============================================================================
+
+function _tasksApi(method, path, body) {
+  var url = 'https://tasks.googleapis.com/tasks/v1' + path;
+  var opts = {
+    method: method,
+    headers: {'Authorization': 'Bearer ' + ScriptApp.getOAuthToken()},
+    contentType: 'application/json',
+    muteHttpExceptions: true
+  };
+  if (body) opts.payload = JSON.stringify(body);
+  var resp = UrlFetchApp.fetch(url, opts);
+  var code = resp.getResponseCode();
+  if (code >= 400) throw new Error('Tasks API ' + code + ': ' + resp.getContentText());
+  var text = resp.getContentText();
+  return text ? JSON.parse(text) : {};
+}
+
+function listTaskLists(p) {
+  var max = p.max_results || 20;
+  var data = _tasksApi('get', '/users/@me/lists?maxResults=' + max);
+  return (data.items || []).map(function(tl) {
+    return {id: tl.id, title: tl.title, updated: tl.updated};
+  });
+}
+
+function getTasks(p) {
+  var listId = p.tasklist_id || '@default';
+  var qs = '?maxResults=' + (p.max_results || 20);
+  if (p.show_completed === false) qs += '&showCompleted=false';
+  if (p.show_hidden) qs += '&showHidden=true';
+  var data = _tasksApi('get', '/lists/' + encodeURIComponent(listId) + '/tasks' + qs);
+  return (data.items || []).map(function(t) {
+    return {id: t.id, title: t.title, status: t.status, due: t.due || null, notes: t.notes || null};
+  });
+}
+
+function createTask(p) {
+  var listId = p.tasklist_id || '@default';
+  var body = {title: p.title};
+  if (p.notes) body.notes = p.notes;
+  if (p.due) body.due = p.due;
+  var task = _tasksApi('post', '/lists/' + encodeURIComponent(listId) + '/tasks', body);
+  return {id: task.id, title: task.title, status: task.status, due: task.due || null};
+}
+
+function updateTask(p) {
+  var listId = p.tasklist_id || '@default';
+  var existing = _tasksApi('get', '/lists/' + encodeURIComponent(listId) + '/tasks/' + encodeURIComponent(p.task_id));
+  if (p.title !== undefined) existing.title = p.title;
+  if (p.notes !== undefined) existing.notes = p.notes;
+  if (p.due !== undefined) existing.due = p.due;
+  if (p.status !== undefined) existing.status = p.status;
+  var updated = _tasksApi('put', '/lists/' + encodeURIComponent(listId) + '/tasks/' + encodeURIComponent(p.task_id), existing);
+  return {id: updated.id, title: updated.title, status: updated.status, due: updated.due || null};
+}
+
+function deleteTask(p) {
+  var listId = p.tasklist_id || '@default';
+  _tasksApi('delete', '/lists/' + encodeURIComponent(listId) + '/tasks/' + encodeURIComponent(p.task_id));
+  return {deleted: true, task_id: p.task_id, tasklist_id: listId};
+}
+
+function completeTask(p) {
+  var listId = p.tasklist_id || '@default';
+  var existing = _tasksApi('get', '/lists/' + encodeURIComponent(listId) + '/tasks/' + encodeURIComponent(p.task_id));
+  existing.status = 'completed';
+  var updated = _tasksApi('put', '/lists/' + encodeURIComponent(listId) + '/tasks/' + encodeURIComponent(p.task_id), existing);
+  return {id: updated.id, title: updated.title, status: 'completed'};
 }

--- a/src/google_automation_mcp/tools/__init__.py
+++ b/src/google_automation_mcp/tools/__init__.py
@@ -8,19 +8,13 @@ https://github.com/taylorwilsdon/google_workspace_mcp
 Licensed under MIT License.
 """
 
+import importlib
+import os
+
 # Authentication tools - imported directly, not from appscript_tools to avoid circular imports
 from .auth_tools import (
     start_google_auth,
     complete_google_auth,
-)
-
-# Gmail tools
-from .gmail import (
-    search_gmail_messages,
-    get_gmail_message,
-    send_gmail_message,
-    list_gmail_labels,
-    modify_gmail_labels,
 )
 
 # Drive tools
@@ -82,6 +76,28 @@ from .forms import (
     create_form,
     add_form_question,
 )
+
+
+# Gmail tools — conditionally loaded from router (clasp) or REST (OAuth/GCP)
+def _use_router() -> bool:
+    override = os.getenv("MCP_USE_ROUTER", "auto")
+    if override == "true":
+        return True
+    if override == "false":
+        return False
+    from ..auth.oauth_config import is_oauth_configured
+
+    return not is_oauth_configured()
+
+
+_gmail_mod = importlib.import_module(
+    ".gmail_router" if _use_router() else ".gmail", __package__
+)
+search_gmail_messages = _gmail_mod.search_gmail_messages
+get_gmail_message = _gmail_mod.get_gmail_message
+send_gmail_message = _gmail_mod.send_gmail_message
+list_gmail_labels = _gmail_mod.list_gmail_labels
+modify_gmail_labels = _gmail_mod.modify_gmail_labels
 
 
 # Lazy imports for Apps Script tools to avoid circular imports

--- a/src/google_automation_mcp/tools/__init__.py
+++ b/src/google_automation_mcp/tools/__init__.py
@@ -17,68 +17,7 @@ from .auth_tools import (
     complete_google_auth,
 )
 
-# Drive tools
-from .drive import (
-    search_drive_files,
-    list_drive_items,
-    get_drive_file_content,
-    create_drive_file,
-    create_drive_folder,
-    delete_drive_file,
-    trash_drive_file,
-    share_drive_file,
-    list_drive_permissions,
-    remove_drive_permission,
-)
 
-# Sheets tools
-from .sheets import (
-    list_spreadsheets,
-    get_sheet_values,
-    update_sheet_values,
-    create_spreadsheet,
-    append_sheet_values,
-    get_spreadsheet_metadata,
-)
-
-# Calendar tools
-from .calendar import (
-    list_calendars,
-    get_events,
-    create_event,
-    delete_event,
-    update_event,
-)
-
-# Docs tools
-from .docs import (
-    search_docs,
-    get_doc_content,
-    create_doc,
-    modify_doc_text,
-    append_doc_text,
-)
-
-# Tasks tools
-from .tasks import (
-    list_task_lists,
-    get_tasks,
-    create_task,
-    update_task,
-    delete_task,
-    complete_task,
-)
-
-# Forms tools
-from .forms import (
-    get_form,
-    get_form_responses,
-    create_form,
-    add_form_question,
-)
-
-
-# Gmail tools — conditionally loaded from router (clasp) or REST (OAuth/GCP)
 def _use_router() -> bool:
     override = os.getenv("MCP_USE_ROUTER", "auto")
     if override == "true":
@@ -90,14 +29,78 @@ def _use_router() -> bool:
     return not is_oauth_configured()
 
 
-_gmail_mod = importlib.import_module(
-    ".gmail_router" if _use_router() else ".gmail", __package__
-)
-search_gmail_messages = _gmail_mod.search_gmail_messages
-get_gmail_message = _gmail_mod.get_gmail_message
-send_gmail_message = _gmail_mod.send_gmail_message
-list_gmail_labels = _gmail_mod.list_gmail_labels
-modify_gmail_labels = _gmail_mod.modify_gmail_labels
+_ROUTER = _use_router()
+
+
+def _mod(router_name: str, rest_name: str, use_router: bool = _ROUTER):
+    return importlib.import_module(
+        f".{router_name}" if use_router else f".{rest_name}", __package__
+    )
+
+
+# Gmail
+_m = _mod("gmail_router", "gmail")
+search_gmail_messages = _m.search_gmail_messages
+get_gmail_message = _m.get_gmail_message
+send_gmail_message = _m.send_gmail_message
+list_gmail_labels = _m.list_gmail_labels
+modify_gmail_labels = _m.modify_gmail_labels
+
+# Drive
+_m = _mod("drive_router", "drive")
+search_drive_files = _m.search_drive_files
+list_drive_items = _m.list_drive_items
+get_drive_file_content = _m.get_drive_file_content
+create_drive_file = _m.create_drive_file
+create_drive_folder = _m.create_drive_folder
+delete_drive_file = _m.delete_drive_file
+trash_drive_file = _m.trash_drive_file
+share_drive_file = _m.share_drive_file
+list_drive_permissions = _m.list_drive_permissions
+remove_drive_permission = _m.remove_drive_permission
+
+# Sheets
+_m = _mod("sheets_router", "sheets")
+list_spreadsheets = _m.list_spreadsheets
+get_sheet_values = _m.get_sheet_values
+update_sheet_values = _m.update_sheet_values
+create_spreadsheet = _m.create_spreadsheet
+append_sheet_values = _m.append_sheet_values
+get_spreadsheet_metadata = _m.get_spreadsheet_metadata
+
+# Calendar
+_m = _mod("calendar_router", "calendar")
+list_calendars = _m.list_calendars
+get_events = _m.get_events
+create_event = _m.create_event
+delete_event = _m.delete_event
+update_event = _m.update_event
+
+# Docs
+_m = _mod("docs_router", "docs")
+search_docs = _m.search_docs
+get_doc_content = _m.get_doc_content
+create_doc = _m.create_doc
+modify_doc_text = _m.modify_doc_text
+append_doc_text = _m.append_doc_text
+
+# Tasks
+_m = _mod("tasks_router", "tasks")
+list_task_lists = _m.list_task_lists
+get_tasks = _m.get_tasks
+create_task = _m.create_task
+update_task = _m.update_task
+delete_task = _m.delete_task
+complete_task = _m.complete_task
+
+# Forms
+_m = _mod("forms_router", "forms")
+get_form = _m.get_form
+get_form_responses = _m.get_form_responses
+create_form = _m.create_form
+add_form_question = _m.add_form_question
+
+del _m, _ROUTER
 
 
 # Lazy imports for Apps Script tools to avoid circular imports
@@ -129,76 +132,22 @@ def __getattr__(name):
 
 
 __all__ = [
-    # Auth
-    "start_google_auth",
-    "complete_google_auth",
-    # Apps Script Projects
-    "list_script_projects",
-    "get_script_project",
-    "get_script_content",
-    "create_script_project",
-    "delete_script_project",
-    "update_script_content",
-    "run_script_function",
-    # Deployments
-    "create_deployment",
-    "list_deployments",
-    "update_deployment",
-    "delete_deployment",
-    # Versions
-    "list_versions",
-    "create_version",
-    "get_version",
-    # Processes
-    "list_script_processes",
-    # Metrics
-    "get_script_metrics",
-    # Gmail
-    "search_gmail_messages",
-    "get_gmail_message",
-    "send_gmail_message",
-    "list_gmail_labels",
-    "modify_gmail_labels",
-    # Drive
-    "search_drive_files",
-    "list_drive_items",
-    "get_drive_file_content",
-    "create_drive_file",
-    "create_drive_folder",
-    "delete_drive_file",
-    "trash_drive_file",
-    "share_drive_file",
-    "list_drive_permissions",
+    "start_google_auth", "complete_google_auth",
+    "list_script_projects", "get_script_project", "get_script_content",
+    "create_script_project", "delete_script_project", "update_script_content",
+    "run_script_function", "create_deployment", "list_deployments",
+    "update_deployment", "delete_deployment", "list_versions", "create_version",
+    "get_version", "list_script_processes", "get_script_metrics",
+    "search_gmail_messages", "get_gmail_message", "send_gmail_message",
+    "list_gmail_labels", "modify_gmail_labels",
+    "search_drive_files", "list_drive_items", "get_drive_file_content",
+    "create_drive_file", "create_drive_folder", "delete_drive_file",
+    "trash_drive_file", "share_drive_file", "list_drive_permissions",
     "remove_drive_permission",
-    # Sheets
-    "list_spreadsheets",
-    "get_sheet_values",
-    "update_sheet_values",
-    "create_spreadsheet",
-    "append_sheet_values",
-    "get_spreadsheet_metadata",
-    # Calendar
-    "list_calendars",
-    "get_events",
-    "create_event",
-    "delete_event",
-    "update_event",
-    # Docs
-    "search_docs",
-    "get_doc_content",
-    "create_doc",
-    "modify_doc_text",
-    "append_doc_text",
-    # Tasks
-    "list_task_lists",
-    "get_tasks",
-    "create_task",
-    "update_task",
-    "delete_task",
-    "complete_task",
-    # Forms
-    "get_form",
-    "get_form_responses",
-    "create_form",
-    "add_form_question",
+    "list_spreadsheets", "get_sheet_values", "update_sheet_values",
+    "create_spreadsheet", "append_sheet_values", "get_spreadsheet_metadata",
+    "list_calendars", "get_events", "create_event", "delete_event", "update_event",
+    "search_docs", "get_doc_content", "create_doc", "modify_doc_text", "append_doc_text",
+    "list_task_lists", "get_tasks", "create_task", "update_task", "delete_task", "complete_task",
+    "get_form", "get_form_responses", "create_form", "add_form_question",
 ]

--- a/src/google_automation_mcp/tools/calendar_router.py
+++ b/src/google_automation_mcp/tools/calendar_router.py
@@ -1,0 +1,104 @@
+"""Calendar tools — Apps Script Router backend."""
+
+import logging
+from typing import Optional
+
+from ..router.client import call_router
+from .error_handler import handle_errors
+
+logger = logging.getLogger(__name__)
+
+
+@handle_errors
+async def list_calendars(user_google_email: str) -> str:
+    logger.info(f"[list_calendars] User: {user_google_email}")
+    results = await call_router(user_google_email, "list_calendars", {})
+    if not results:
+        return "No calendars found."
+    output = [f"Found {len(results)} calendars:"]
+    for cal in results:
+        primary = " (primary)" if cal.get("is_primary") else ""
+        output.append(f"- {cal.get('name', 'Untitled')}{primary}\n  ID: {cal.get('id')}")
+    return "\n".join(output)
+
+
+@handle_errors
+async def get_events(
+    user_google_email: str, calendar_id: str = "primary",
+    max_results: int = 10, time_min: Optional[str] = None,
+    time_max: Optional[str] = None, query: Optional[str] = None,
+) -> str:
+    logger.info(f"[get_events] User: {user_google_email}, Calendar: {calendar_id}")
+    results = await call_router(user_google_email, "get_events", {
+        "calendar_id": calendar_id, "max_results": max_results,
+        "time_min": time_min, "time_max": time_max, "query": query,
+    })
+    if not results:
+        return f"No events found in calendar '{calendar_id}' for the specified time range."
+    output = [f"Found {len(results)} events in '{calendar_id}':"]
+    for ev in results:
+        entry = [f"\n- {ev.get('summary', '(No title)')}", f"  ID: {ev['id']}"]
+        if ev.get("all_day"):
+            entry.append(f"  Time: All-day: {ev['start']}")
+        else:
+            entry.append(f"  Time: {ev['start']} - {ev.get('end', '')}")
+        if ev.get("location"):
+            entry.append(f"  Location: {ev['location']}")
+        output.extend(entry)
+    return "\n".join(output)
+
+
+@handle_errors
+async def create_event(
+    user_google_email: str, summary: str, start_time: str, end_time: str,
+    calendar_id: str = "primary", description: Optional[str] = None,
+    location: Optional[str] = None, attendees: Optional[str] = None,
+    all_day: bool = False,
+) -> str:
+    logger.info(f"[create_event] User: {user_google_email}, Summary: {summary}")
+    result = await call_router(user_google_email, "create_event", {
+        "summary": summary, "start_time": start_time, "end_time": end_time,
+        "calendar_id": calendar_id, "description": description,
+        "location": location, "attendees": attendees, "all_day": all_day,
+    })
+    output = [
+        f"Created event: {result.get('summary', summary)}",
+        f"ID: {result['id']}", f"Calendar: {calendar_id}",
+        f"Start: {result.get('start', start_time)}",
+    ]
+    return "\n".join(output)
+
+
+@handle_errors
+async def update_event(
+    user_google_email: str, event_id: str, calendar_id: str = "primary",
+    summary: Optional[str] = None, start_time: Optional[str] = None,
+    end_time: Optional[str] = None, description: Optional[str] = None,
+    location: Optional[str] = None, attendees: Optional[str] = None,
+    all_day: bool = False,
+) -> str:
+    logger.info(f"[update_event] User: {user_google_email}, Event: {event_id}")
+    if not any([summary, start_time, end_time, description, location, attendees]):
+        return "No fields to update. Provide at least one field to modify."
+    result = await call_router(user_google_email, "update_event", {
+        "event_id": event_id, "calendar_id": calendar_id,
+        "summary": summary, "start_time": start_time, "end_time": end_time,
+        "description": description, "location": location, "attendees": attendees,
+    })
+    output = [
+        f"Updated event: {result.get('summary', '')}",
+        f"ID: {result['id']}", f"Calendar: {calendar_id}",
+        f"Start: {result.get('start', '')}",
+    ]
+    return "\n".join(output)
+
+
+@handle_errors
+async def delete_event(
+    user_google_email: str, event_id: str, calendar_id: str = "primary",
+) -> str:
+    logger.info(f"[delete_event] User: {user_google_email}, Event: {event_id}")
+    await call_router(user_google_email, "delete_event", {
+        "event_id": event_id, "calendar_id": calendar_id,
+    })
+    return f"Deleted event: {event_id} from calendar: {calendar_id}"

--- a/src/google_automation_mcp/tools/docs_router.py
+++ b/src/google_automation_mcp/tools/docs_router.py
@@ -1,0 +1,80 @@
+"""Docs tools — Apps Script Router backend."""
+
+import logging
+from typing import Optional
+
+from ..router.client import call_router
+from .error_handler import handle_errors
+
+logger = logging.getLogger(__name__)
+
+
+@handle_errors
+async def search_docs(
+    user_google_email: str, query: str, page_size: int = 10,
+) -> str:
+    logger.info(f"[search_docs] User: {user_google_email}, Query: '{query}'")
+    results = await call_router(user_google_email, "search_docs", {
+        "query": query, "page_size": page_size,
+    })
+    if not results:
+        return f"No Google Docs found matching '{query}'."
+    output = [f"Found {len(results)} Google Docs matching '{query}':"]
+    for doc in results:
+        output.append(
+            f"- {doc['name']} (ID: {doc['id']})\n"
+            f"  Modified: {doc.get('modified', 'N/A')}\n"
+            f"  Link: {doc.get('url', '#')}"
+        )
+    return "\n".join(output)
+
+
+@handle_errors
+async def get_doc_content(user_google_email: str, document_id: str) -> str:
+    logger.info(f"[get_doc_content] User: {user_google_email}, Doc: {document_id}")
+    result = await call_router(user_google_email, "get_doc_content", {
+        "document_id": document_id,
+    })
+    link = result.get("url", f"https://docs.google.com/document/d/{document_id}/edit")
+    header = f"Document: {result.get('title', 'Untitled')}\nID: {document_id}\nLink: {link}\n\n--- CONTENT ---\n"
+    return header + result.get("content", "")
+
+
+@handle_errors
+async def create_doc(
+    user_google_email: str, title: str, content: str = "",
+) -> str:
+    logger.info(f"[create_doc] User: {user_google_email}, Title: {title}")
+    result = await call_router(user_google_email, "create_doc", {
+        "title": title, "content": content,
+    })
+    link = result.get("url", f"https://docs.google.com/document/d/{result['document_id']}/edit")
+    return f"Created Google Doc: {title}\nID: {result['document_id']}\nLink: {link}"
+
+
+@handle_errors
+async def modify_doc_text(
+    user_google_email: str, document_id: str, text: str,
+    index: int = 1, replace_text: Optional[str] = None,
+) -> str:
+    logger.info(f"[modify_doc_text] User: {user_google_email}, Doc: {document_id}")
+    result = await call_router(user_google_email, "modify_doc_text", {
+        "document_id": document_id, "text": text,
+        "index": index, "replace_text": replace_text,
+    })
+    link = result.get("url", f"https://docs.google.com/document/d/{document_id}/edit")
+    if replace_text:
+        return f"Replaced text in document\nDocument: {document_id}\nLink: {link}"
+    return f"Inserted text at index {index}\nDocument: {document_id}\nLink: {link}"
+
+
+@handle_errors
+async def append_doc_text(
+    user_google_email: str, document_id: str, text: str,
+) -> str:
+    logger.info(f"[append_doc_text] User: {user_google_email}, Doc: {document_id}")
+    result = await call_router(user_google_email, "append_doc_text", {
+        "document_id": document_id, "text": text,
+    })
+    link = result.get("url", f"https://docs.google.com/document/d/{document_id}/edit")
+    return f"Appended text to document\nDocument: {document_id}\nLink: {link}"

--- a/src/google_automation_mcp/tools/drive_router.py
+++ b/src/google_automation_mcp/tools/drive_router.py
@@ -1,0 +1,148 @@
+"""Drive tools — Apps Script Router backend."""
+
+import logging
+from ..router.client import call_router
+from .error_handler import handle_errors
+
+logger = logging.getLogger(__name__)
+
+
+@handle_errors
+async def search_drive_files(
+    user_google_email: str, query: str, page_size: int = 10,
+    include_shared_drives: bool = True,
+) -> str:
+    logger.info(f"[search_drive_files] User: {user_google_email}, Query: '{query}'")
+    results = await call_router(user_google_email, "search_drive", {
+        "query": query, "page_size": page_size,
+    })
+    if not results:
+        return f"No files found for query: '{query}'"
+    output = [f"Found {len(results)} files matching '{query}':"]
+    for item in results:
+        size_str = f", Size: {item.get('size', 'N/A')}" if item.get("size") else ""
+        output.append(
+            f"- {item['name']} (ID: {item['id']})\n"
+            f"  Type: {item.get('mime_type', 'N/A')}{size_str}\n"
+            f"  Modified: {item.get('modified', 'N/A')}\n"
+            f"  Link: {item.get('url', '#')}"
+        )
+    return "\n".join(output)
+
+
+@handle_errors
+async def list_drive_items(
+    user_google_email: str, folder_id: str = "root", page_size: int = 50,
+    include_shared_drives: bool = True,
+) -> str:
+    logger.info(f"[list_drive_items] User: {user_google_email}, Folder: {folder_id}")
+    result = await call_router(user_google_email, "list_drive", {
+        "folder_id": folder_id, "page_size": page_size,
+    })
+    folders = result.get("folders", [])
+    files = result.get("files", [])
+    total = len(folders) + len(files)
+    if total == 0:
+        return f"No items found in folder '{folder_id}'"
+    output = [f"Found {total} items in folder '{folder_id}':"]
+    if folders:
+        output.append("\nFolders:")
+        for f in folders:
+            output.append(f"  📁 {f['name']} (ID: {f['id']})")
+    if files:
+        output.append("\nFiles:")
+        for f in files:
+            size_str = f" [{f.get('size', 'N/A')} bytes]" if f.get("size") else ""
+            output.append(f"  📄 {f['name']}{size_str} (ID: {f['id']})")
+    return "\n".join(output)
+
+
+@handle_errors
+async def get_drive_file_content(user_google_email: str, file_id: str) -> str:
+    logger.info(f"[get_drive_file_content] User: {user_google_email}, File: {file_id}")
+    result = await call_router(user_google_email, "get_drive_content", {
+        "file_id": file_id,
+    })
+    header = (
+        f'File: "{result["name"]}" (ID: {result["id"]})\n'
+        f"Type: {result.get('mime_type', 'N/A')}\n"
+        f"Link: {result.get('url', '#')}\n\n"
+        f"--- CONTENT ---\n"
+    )
+    return header + result.get("content", "")
+
+
+@handle_errors
+async def create_drive_file(
+    user_google_email: str, file_name: str, content: str = "",
+    folder_id: str = "root", mime_type: str = "text/plain",
+) -> str:
+    logger.info(f"[create_drive_file] User: {user_google_email}, Name: {file_name}")
+    result = await call_router(user_google_email, "create_drive_file", {
+        "file_name": file_name, "content": content,
+        "folder_id": folder_id, "mime_type": mime_type,
+    })
+    return f"Created file: {result['name']}\nID: {result['id']}\nLink: {result.get('url', '#')}"
+
+
+@handle_errors
+async def create_drive_folder(
+    user_google_email: str, folder_name: str, parent_id: str = "root",
+) -> str:
+    logger.info(f"[create_drive_folder] User: {user_google_email}, Name: {folder_name}")
+    result = await call_router(user_google_email, "create_drive_folder", {
+        "folder_name": folder_name, "parent_id": parent_id,
+    })
+    return f"Created folder: {result['name']}\nID: {result['id']}\nLink: {result.get('url', '#')}"
+
+
+@handle_errors
+async def delete_drive_file(user_google_email: str, file_id: str) -> str:
+    logger.info(f"[delete_drive_file] User: {user_google_email}, File: {file_id}")
+    await call_router(user_google_email, "delete_drive_file", {"file_id": file_id})
+    return f"Permanently deleted file: {file_id}"
+
+
+@handle_errors
+async def trash_drive_file(user_google_email: str, file_id: str) -> str:
+    logger.info(f"[trash_drive_file] User: {user_google_email}, File: {file_id}")
+    await call_router(user_google_email, "trash_drive_file", {"file_id": file_id})
+    return f"Moved to trash: {file_id}"
+
+
+@handle_errors
+async def share_drive_file(
+    user_google_email: str, file_id: str, email: str,
+    role: str = "reader", send_notification: bool = True,
+) -> str:
+    logger.info(f"[share_drive_file] User: {user_google_email}, File: {file_id}")
+    await call_router(user_google_email, "share_drive_file", {
+        "file_id": file_id, "email": email, "role": role,
+    })
+    return f"Shared file: {file_id}\nWith: {email}\nRole: {role}"
+
+
+@handle_errors
+async def list_drive_permissions(user_google_email: str, file_id: str) -> str:
+    logger.info(f"[list_drive_permissions] User: {user_google_email}, File: {file_id}")
+    result = await call_router(user_google_email, "list_drive_permissions", {
+        "file_id": file_id,
+    })
+    perms = result.get("permissions", [])
+    if not perms:
+        return f"No permissions found for file: {file_id}"
+    output = [f"Permissions for file {file_id}:"]
+    for p in perms:
+        output.append(f"  - {p.get('email', 'unknown')} ({p.get('role', 'unknown')})")
+    return "\n".join(output)
+
+
+@handle_errors
+async def remove_drive_permission(
+    user_google_email: str, file_id: str, permission_id: str,
+) -> str:
+    logger.info(f"[remove_drive_permission] User: {user_google_email}, File: {file_id}")
+    await call_router(user_google_email, "remove_drive_permission", {
+        "file_id": file_id, "permission_id": permission_id,
+    })
+    return f"Removed permission {permission_id} from file {file_id}"

--- a/src/google_automation_mcp/tools/forms_router.py
+++ b/src/google_automation_mcp/tools/forms_router.py
@@ -1,0 +1,78 @@
+"""Forms tools — Apps Script Router backend."""
+
+import logging
+from typing import Optional
+
+from ..router.client import call_router
+from .error_handler import handle_errors
+
+logger = logging.getLogger(__name__)
+
+
+@handle_errors
+async def get_form(user_google_email: str, form_id: str) -> str:
+    logger.info(f"[get_form] User: {user_google_email}, Form: {form_id}")
+    result = await call_router(user_google_email, "get_form", {"form_id": form_id})
+    output = [
+        f"Form: {result.get('title', 'Untitled')}",
+        f"ID: {result.get('form_id')}",
+        f"URL: {result.get('url', 'N/A')}",
+    ]
+    if result.get("description"):
+        output.append(f"Description: {result['description']}")
+    items = result.get("items", [])
+    if items:
+        output.append(f"\nQuestions ({len(items)}):")
+        for item in items:
+            output.append(f"  {item['index']}. {item['title']} [{item.get('type', '')}] (ID: {item.get('item_id', '')})")
+    return "\n".join(output)
+
+
+@handle_errors
+async def get_form_responses(
+    user_google_email: str, form_id: str, max_results: int = 50,
+) -> str:
+    logger.info(f"[get_form_responses] User: {user_google_email}, Form: {form_id}")
+    results = await call_router(user_google_email, "get_form_responses", {
+        "form_id": form_id, "max_results": max_results,
+    })
+    if not results:
+        return f"No responses found for form '{form_id}'."
+    output = [f"Found {len(results)} responses:"]
+    for resp in results:
+        output.append(f"\n--- Response {resp.get('response_id', '')} (submitted: {resp.get('timestamp', '')}) ---")
+        for ans in resp.get("answers", []):
+            output.append(f"  {ans.get('question', '?')}: {ans.get('answer', '')}")
+    return "\n".join(output)
+
+
+@handle_errors
+async def create_form(
+    user_google_email: str, title: str, description: Optional[str] = None,
+) -> str:
+    logger.info(f"[create_form] User: {user_google_email}, Title: {title}")
+    result = await call_router(user_google_email, "create_form", {
+        "title": title, "description": description,
+    })
+    return (
+        f"Created form: {result.get('title', title)}\n"
+        f"ID: {result.get('form_id')}\n"
+        f"Edit URL: {result.get('edit_url', 'N/A')}\n"
+        f"Response URL: {result.get('url', 'N/A')}"
+    )
+
+
+@handle_errors
+async def add_form_question(
+    user_google_email: str, form_id: str, title: str,
+    question_type: str = "TEXT", required: bool = False,
+    choices: Optional[str] = None,
+) -> str:
+    logger.info(f"[add_form_question] User: {user_google_email}, Form: {form_id}")
+    if question_type in ("MULTIPLE_CHOICE", "CHECKBOX", "DROP_DOWN") and not choices:
+        return f"Question type '{question_type}' requires choices. Provide comma-separated options."
+    result = await call_router(user_google_email, "add_form_question", {
+        "form_id": form_id, "title": title,
+        "question_type": question_type, "required": required, "choices": choices,
+    })
+    return f"Added question '{title}' ({result.get('type', question_type)}) to form {form_id}"

--- a/src/google_automation_mcp/tools/gmail_router.py
+++ b/src/google_automation_mcp/tools/gmail_router.py
@@ -1,0 +1,162 @@
+"""
+Gmail Tools — Apps Script Router Backend
+
+Same interface as gmail.py but routes through the Apps Script Web App
+instead of calling Gmail REST API directly. Works with clasp auth only,
+no GCP project needed.
+"""
+
+import logging
+from typing import Optional, List
+
+from ..router.client import call_router
+from .error_handler import handle_errors
+
+logger = logging.getLogger(__name__)
+
+
+@handle_errors
+async def search_gmail_messages(
+    user_google_email: str,
+    query: str = "",
+    max_results: int = 10,
+    label_ids: Optional[List[str]] = None,
+) -> str:
+    logger.info(f"[search_gmail_messages] User: {user_google_email}, Query: '{query}'")
+
+    results = await call_router(user_google_email, "search_gmail", {
+        "query": query,
+        "max_results": max_results,
+    })
+
+    if not results:
+        return f"No messages found for query: '{query}'"
+
+    output = [f"Found {len(results)} messages for '{query}':"]
+    for msg in results:
+        output.append(f"\n- ID: {msg['message_id']}")
+        output.append(f"  From: {msg['from']}")
+        output.append(f"  Subject: {msg['subject']}")
+        output.append(f"  Date: {msg['date']}")
+        output.append(f"  Preview: {msg.get('snippet', '')[:100]}...")
+        if msg.get("labels"):
+            output.append(f"  Labels: {', '.join(msg['labels'])}")
+
+    return "\n".join(output)
+
+
+@handle_errors
+async def get_gmail_message(
+    user_google_email: str,
+    message_id: str,
+    format: str = "full",
+) -> str:
+    logger.info(
+        f"[get_gmail_message] User: {user_google_email}, Message ID: {message_id}"
+    )
+
+    msg = await call_router(user_google_email, "get_gmail_message", {
+        "message_id": message_id,
+    })
+
+    output = [
+        f"Message ID: {msg['id']}",
+        f"From: {msg['from']}",
+        f"To: {msg['to']}",
+        f"Subject: {msg['subject']}",
+        f"Date: {msg['date']}",
+    ]
+    if msg.get("cc"):
+        output.append(f"CC: {msg['cc']}")
+    if msg.get("attachments"):
+        output.append(f"Attachments: {len(msg['attachments'])}")
+        for att in msg["attachments"]:
+            output.append(f"  - {att['name']} ({att['type']}, {att['size']} bytes)")
+
+    output.append("")
+    if msg.get("body"):
+        output.append("--- Content ---")
+        output.append(msg["body"][:5000])
+        if len(msg.get("body", "")) > 5000:
+            output.append("... (truncated)")
+
+    return "\n".join(output)
+
+
+@handle_errors
+async def send_gmail_message(
+    user_google_email: str,
+    to: str,
+    subject: str,
+    body: str,
+    cc: Optional[str] = None,
+    bcc: Optional[str] = None,
+    html: bool = False,
+) -> str:
+    logger.info(
+        f"[send_gmail_message] User: {user_google_email}, To: {to}, Subject: {subject}"
+    )
+
+    await call_router(user_google_email, "send_gmail", {
+        "to": to,
+        "subject": subject,
+        "body": body,
+        "cc": cc,
+        "bcc": bcc,
+        "html": html,
+    })
+
+    return f"Message sent successfully!\nTo: {to}\nSubject: {subject}"
+
+
+@handle_errors
+async def list_gmail_labels(
+    user_google_email: str,
+) -> str:
+    logger.info(f"[list_gmail_labels] User: {user_google_email}")
+
+    result = await call_router(user_google_email, "list_gmail_labels", {})
+
+    user_labels = result.get("user_labels", [])
+    note = result.get("note", "")
+
+    output = [f"Found {len(user_labels)} user labels:"]
+
+    if user_labels:
+        output.append("\nUser Labels:")
+        for label in sorted(user_labels, key=lambda x: x.get("name", "")):
+            output.append(f"  - {label['name']}")
+
+    if note:
+        output.append(f"\nNote: {note}")
+
+    return "\n".join(output)
+
+
+@handle_errors
+async def modify_gmail_labels(
+    user_google_email: str,
+    message_id: str,
+    add_labels: Optional[List[str]] = None,
+    remove_labels: Optional[List[str]] = None,
+) -> str:
+    logger.info(
+        f"[modify_gmail_labels] User: {user_google_email}, Message: {message_id}"
+    )
+
+    if not add_labels and not remove_labels:
+        return "No labels to modify. Provide add_labels or remove_labels."
+
+    result = await call_router(user_google_email, "modify_gmail_labels", {
+        "message_id": message_id,
+        "add_labels": add_labels or [],
+        "remove_labels": remove_labels or [],
+    })
+
+    output = [f"Modified message: {result['message_id']}"]
+    if result.get("added"):
+        output.append(f"Added: {', '.join(result['added'])}")
+    if result.get("removed"):
+        output.append(f"Removed: {', '.join(result['removed'])}")
+
+    return "\n".join(output)

--- a/src/google_automation_mcp/tools/sheets_router.py
+++ b/src/google_automation_mcp/tools/sheets_router.py
@@ -1,0 +1,127 @@
+"""Sheets tools — Apps Script Router backend."""
+
+import logging
+from typing import Optional, List
+
+from ..router.client import call_router
+from .error_handler import handle_errors
+
+logger = logging.getLogger(__name__)
+
+
+@handle_errors
+async def list_spreadsheets(
+    user_google_email: str, query: str = "", page_size: int = 20,
+) -> str:
+    logger.info(f"[list_spreadsheets] User: {user_google_email}")
+    results = await call_router(user_google_email, "list_spreadsheets", {
+        "query": query, "page_size": page_size,
+    })
+    if not results:
+        return f"No spreadsheets found{' matching: ' + query if query else ''}."
+    output = [f"Found {len(results)} spreadsheets{' matching: ' + query if query else ''}:"]
+    for f in results:
+        output.append(
+            f"- {f['name']} (ID: {f['id']})\n"
+            f"  Modified: {f.get('modified', 'N/A')}\n"
+            f"  Link: {f.get('url', '#')}"
+        )
+    return "\n".join(output)
+
+
+@handle_errors
+async def get_sheet_values(
+    user_google_email: str, spreadsheet_id: str,
+    range: str = "Sheet1", value_render: str = "FORMATTED_VALUE",
+) -> str:
+    logger.info(f"[get_sheet_values] User: {user_google_email}, Sheet: {spreadsheet_id}")
+    result = await call_router(user_google_email, "get_sheet_values", {
+        "spreadsheet_id": spreadsheet_id, "range": range,
+    })
+    values = result.get("values", [])
+    if not values:
+        return f"No data found in range '{range}'."
+    output = [
+        f"Spreadsheet: {spreadsheet_id}", f"Range: {range}",
+        f"Rows: {len(values)}", "", "--- DATA ---",
+    ]
+    for i, row in enumerate(values):
+        row_str = " | ".join(str(cell) for cell in row)
+        output.append(f"Row {i + 1}: {row_str}")
+    output.append(f"\nLink: https://docs.google.com/spreadsheets/d/{spreadsheet_id}/edit")
+    return "\n".join(output)
+
+
+@handle_errors
+async def update_sheet_values(
+    user_google_email: str, spreadsheet_id: str, range: str,
+    values: List[List[str]], value_input: str = "USER_ENTERED",
+) -> str:
+    logger.info(f"[update_sheet_values] User: {user_google_email}, Sheet: {spreadsheet_id}")
+    result = await call_router(user_google_email, "update_sheet_values", {
+        "spreadsheet_id": spreadsheet_id, "range": range, "values": values,
+    })
+    link = f"https://docs.google.com/spreadsheets/d/{spreadsheet_id}/edit"
+    return (
+        f"Updated spreadsheet: {spreadsheet_id}\n"
+        f"Range: {result.get('range', range)}\n"
+        f"Cells updated: {result.get('updated_cells', 0)}\n"
+        f"Rows updated: {result.get('updated_rows', 0)}\n"
+        f"Link: {link}"
+    )
+
+
+@handle_errors
+async def append_sheet_values(
+    user_google_email: str, spreadsheet_id: str, range: str,
+    values: List[List[str]], value_input: str = "USER_ENTERED",
+) -> str:
+    logger.info(f"[append_sheet_values] User: {user_google_email}, Sheet: {spreadsheet_id}")
+    result = await call_router(user_google_email, "append_sheet_values", {
+        "spreadsheet_id": spreadsheet_id, "range": range, "values": values,
+    })
+    link = f"https://docs.google.com/spreadsheets/d/{spreadsheet_id}/edit"
+    return (
+        f"Appended to spreadsheet: {spreadsheet_id}\n"
+        f"Range: {result.get('updated_range', range)}\n"
+        f"Rows added: {result.get('updated_rows', 0)}\n"
+        f"Cells added: {result.get('updated_cells', 0)}\n"
+        f"Link: {link}"
+    )
+
+
+@handle_errors
+async def create_spreadsheet(
+    user_google_email: str, title: str,
+    sheet_names: Optional[List[str]] = None,
+) -> str:
+    logger.info(f"[create_spreadsheet] User: {user_google_email}, Title: {title}")
+    result = await call_router(user_google_email, "create_spreadsheet", {
+        "title": title, "sheet_names": sheet_names,
+    })
+    sheets = result.get("sheets", ["Sheet1"])
+    return (
+        f"Created spreadsheet: {title}\n"
+        f"ID: {result['spreadsheet_id']}\n"
+        f"Sheets: {', '.join(sheets)}\n"
+        f"Link: {result.get('url', '#')}"
+    )
+
+
+@handle_errors
+async def get_spreadsheet_metadata(
+    user_google_email: str, spreadsheet_id: str,
+) -> str:
+    logger.info(f"[get_spreadsheet_metadata] User: {user_google_email}, Sheet: {spreadsheet_id}")
+    result = await call_router(user_google_email, "get_spreadsheet_metadata", {
+        "spreadsheet_id": spreadsheet_id,
+    })
+    sheets = result.get("sheets", [])
+    output = [
+        f"Spreadsheet: {result.get('title', 'Untitled')}",
+        f"ID: {spreadsheet_id}", f"Sheets ({len(sheets)}):",
+    ]
+    for s in sheets:
+        output.append(f"  - {s['title']} (ID: {s.get('sheet_id', 'N/A')}, Rows: {s.get('rows', 'N/A')}, Cols: {s.get('cols', 'N/A')})")
+    output.append(f"\nLink: {result.get('url', '#')}")
+    return "\n".join(output)

--- a/src/google_automation_mcp/tools/tasks_router.py
+++ b/src/google_automation_mcp/tools/tasks_router.py
@@ -1,0 +1,115 @@
+"""Tasks tools — Apps Script Router backend."""
+
+import logging
+from typing import Optional
+
+from ..router.client import call_router
+from .error_handler import handle_errors
+
+logger = logging.getLogger(__name__)
+
+
+@handle_errors
+async def list_task_lists(
+    user_google_email: str, max_results: int = 20,
+) -> str:
+    logger.info(f"[list_task_lists] User: {user_google_email}")
+    results = await call_router(user_google_email, "list_task_lists", {
+        "max_results": max_results,
+    })
+    if not results:
+        return "No task lists found."
+    output = [f"Found {len(results)} task lists:"]
+    for tl in results:
+        output.append(
+            f"- {tl.get('title', 'Untitled')}\n"
+            f"  ID: {tl.get('id')}\n"
+            f"  Updated: {tl.get('updated', 'Unknown')}"
+        )
+    return "\n".join(output)
+
+
+@handle_errors
+async def get_tasks(
+    user_google_email: str, tasklist_id: str = "@default",
+    max_results: int = 20, show_completed: bool = True,
+    show_hidden: bool = False,
+) -> str:
+    logger.info(f"[get_tasks] User: {user_google_email}, List: {tasklist_id}")
+    results = await call_router(user_google_email, "get_tasks", {
+        "tasklist_id": tasklist_id, "max_results": max_results,
+        "show_completed": show_completed, "show_hidden": show_hidden,
+    })
+    if not results:
+        return f"No tasks found in list '{tasklist_id}'."
+    output = [f"Found {len(results)} tasks:"]
+    for task in results:
+        status = "✓" if task.get("status") == "completed" else "○"
+        entry = [f"\n{status} {task.get('title', '(No title)')}", f"  ID: {task.get('id', 'Unknown')}"]
+        if task.get("due"):
+            entry.append(f"  Due: {task['due']}")
+        if task.get("notes"):
+            entry.append(f"  Notes: {task['notes'][:100]}")
+        output.extend(entry)
+    return "\n".join(output)
+
+
+@handle_errors
+async def create_task(
+    user_google_email: str, title: str, tasklist_id: str = "@default",
+    notes: Optional[str] = None, due: Optional[str] = None,
+) -> str:
+    logger.info(f"[create_task] User: {user_google_email}, Title: {title}")
+    result = await call_router(user_google_email, "create_task", {
+        "title": title, "tasklist_id": tasklist_id, "notes": notes, "due": due,
+    })
+    output = [
+        f"Created task: {result.get('title', title)}",
+        f"ID: {result.get('id')}", f"List: {tasklist_id}",
+        f"Status: {result.get('status', 'needsAction')}",
+    ]
+    if result.get("due"):
+        output.append(f"Due: {result['due']}")
+    return "\n".join(output)
+
+
+@handle_errors
+async def update_task(
+    user_google_email: str, task_id: str, tasklist_id: str = "@default",
+    title: Optional[str] = None, notes: Optional[str] = None,
+    due: Optional[str] = None, status: Optional[str] = None,
+) -> str:
+    logger.info(f"[update_task] User: {user_google_email}, Task: {task_id}")
+    result = await call_router(user_google_email, "update_task", {
+        "task_id": task_id, "tasklist_id": tasklist_id,
+        "title": title, "notes": notes, "due": due, "status": status,
+    })
+    output = [
+        f"Updated task: {result.get('title', '')}",
+        f"ID: {result.get('id')}", f"Status: {result.get('status', '')}",
+    ]
+    if result.get("due"):
+        output.append(f"Due: {result['due']}")
+    return "\n".join(output)
+
+
+@handle_errors
+async def delete_task(
+    user_google_email: str, task_id: str, tasklist_id: str = "@default",
+) -> str:
+    logger.info(f"[delete_task] User: {user_google_email}, Task: {task_id}")
+    await call_router(user_google_email, "delete_task", {
+        "task_id": task_id, "tasklist_id": tasklist_id,
+    })
+    return f"Deleted task: {task_id} from list: {tasklist_id}"
+
+
+@handle_errors
+async def complete_task(
+    user_google_email: str, task_id: str, tasklist_id: str = "@default",
+) -> str:
+    logger.info(f"[complete_task] User: {user_google_email}, Task: {task_id}")
+    result = await call_router(user_google_email, "complete_task", {
+        "task_id": task_id, "tasklist_id": tasklist_id,
+    })
+    return f"Completed task: {result.get('title', '')} (ID: {result.get('id', task_id)})"

--- a/tests/test_calendar_router.py
+++ b/tests/test_calendar_router.py
@@ -1,0 +1,94 @@
+"""Tests for Calendar tools backed by the Apps Script router."""
+
+from unittest.mock import patch, AsyncMock
+
+import pytest
+
+from google_automation_mcp.tools.calendar_router import (
+    list_calendars,
+    get_events,
+    create_event,
+    update_event,
+    delete_event,
+)
+
+
+@pytest.fixture
+def mock_call_router():
+    with patch(
+        "google_automation_mcp.tools.calendar_router.call_router",
+        new_callable=AsyncMock,
+    ) as mock:
+        yield mock
+
+
+@pytest.mark.asyncio
+class TestCalendarRouterTools:
+    async def test_list_calendars(self, mock_call_router):
+        mock_call_router.return_value = [
+            {"id": "primary", "name": "My Calendar", "is_primary": True},
+            {"id": "work", "name": "Work", "is_primary": False},
+        ]
+        result = await list_calendars(user_google_email="t@t.com")
+        assert "Found 2 calendars" in result
+        assert "My Calendar" in result
+        assert "(primary)" in result
+
+    async def test_list_calendars_empty(self, mock_call_router):
+        mock_call_router.return_value = []
+        result = await list_calendars(user_google_email="t@t.com")
+        assert "No calendars found" in result
+
+    async def test_get_events(self, mock_call_router):
+        mock_call_router.return_value = [
+            {"id": "e1", "summary": "Meeting", "start": "2026-04-17T10:00:00Z",
+             "end": "2026-04-17T11:00:00Z", "location": "Room A", "all_day": False},
+        ]
+        result = await get_events(user_google_email="t@t.com")
+        assert "Found 1 events" in result
+        assert "Meeting" in result
+        assert "Room A" in result
+
+    async def test_get_events_empty(self, mock_call_router):
+        mock_call_router.return_value = []
+        result = await get_events(user_google_email="t@t.com")
+        assert "No events found" in result
+
+    async def test_get_events_all_day(self, mock_call_router):
+        mock_call_router.return_value = [
+            {"id": "e2", "summary": "Holiday", "start": "2026-04-17",
+             "end": "2026-04-18", "location": "", "all_day": True},
+        ]
+        result = await get_events(user_google_email="t@t.com")
+        assert "All-day" in result
+
+    async def test_create_event(self, mock_call_router):
+        mock_call_router.return_value = {
+            "id": "e1", "summary": "Lunch", "start": "2026-04-17T12:00:00Z",
+            "calendar_id": "primary",
+        }
+        result = await create_event(
+            user_google_email="t@t.com", summary="Lunch",
+            start_time="2026-04-17T12:00:00Z", end_time="2026-04-17T13:00:00Z",
+        )
+        assert "Created event: Lunch" in result
+
+    async def test_update_event(self, mock_call_router):
+        mock_call_router.return_value = {
+            "id": "e1", "summary": "Updated Meeting", "start": "2026-04-17T10:00:00Z",
+            "calendar_id": "primary",
+        }
+        result = await update_event(
+            user_google_email="t@t.com", event_id="e1", summary="Updated Meeting",
+        )
+        assert "Updated event: Updated Meeting" in result
+
+    async def test_update_event_no_fields(self, mock_call_router):
+        result = await update_event(user_google_email="t@t.com", event_id="e1")
+        assert "No fields to update" in result
+        mock_call_router.assert_not_called()
+
+    async def test_delete_event(self, mock_call_router):
+        mock_call_router.return_value = {"deleted": True}
+        result = await delete_event(user_google_email="t@t.com", event_id="e1")
+        assert "Deleted event: e1" in result

--- a/tests/test_docs_router.py
+++ b/tests/test_docs_router.py
@@ -1,0 +1,82 @@
+"""Tests for Docs tools backed by the Apps Script router."""
+
+from unittest.mock import patch, AsyncMock
+
+import pytest
+
+from google_automation_mcp.tools.docs_router import (
+    search_docs,
+    get_doc_content,
+    create_doc,
+    modify_doc_text,
+    append_doc_text,
+)
+
+
+@pytest.fixture
+def mock_call_router():
+    with patch(
+        "google_automation_mcp.tools.docs_router.call_router",
+        new_callable=AsyncMock,
+    ) as mock:
+        yield mock
+
+
+@pytest.mark.asyncio
+class TestDocsRouterTools:
+    async def test_search_docs(self, mock_call_router):
+        mock_call_router.return_value = [
+            {"id": "d1", "name": "My Doc", "modified": "2026-04-17", "url": "https://..."}
+        ]
+        result = await search_docs(user_google_email="t@t.com", query="My")
+        assert "Found 1 Google Docs" in result
+        assert "My Doc" in result
+
+    async def test_search_docs_empty(self, mock_call_router):
+        mock_call_router.return_value = []
+        result = await search_docs(user_google_email="t@t.com", query="nope")
+        assert "No Google Docs found" in result
+
+    async def test_get_doc_content(self, mock_call_router):
+        mock_call_router.return_value = {
+            "document_id": "d1", "title": "My Doc",
+            "content": "Hello world", "url": "https://...",
+        }
+        result = await get_doc_content(user_google_email="t@t.com", document_id="d1")
+        assert "My Doc" in result
+        assert "Hello world" in result
+
+    async def test_create_doc(self, mock_call_router):
+        mock_call_router.return_value = {
+            "document_id": "d1", "title": "New Doc", "url": "https://...",
+        }
+        result = await create_doc(user_google_email="t@t.com", title="New Doc")
+        assert "Created Google Doc: New Doc" in result
+
+    async def test_modify_doc_text_replace(self, mock_call_router):
+        mock_call_router.return_value = {
+            "document_id": "d1", "action": "replace", "url": "https://...",
+        }
+        result = await modify_doc_text(
+            user_google_email="t@t.com", document_id="d1",
+            text="new", replace_text="old",
+        )
+        assert "Replaced text" in result
+
+    async def test_modify_doc_text_insert(self, mock_call_router):
+        mock_call_router.return_value = {
+            "document_id": "d1", "action": "insert", "index": 1, "url": "https://...",
+        }
+        result = await modify_doc_text(
+            user_google_email="t@t.com", document_id="d1", text="inserted",
+        )
+        assert "Inserted text at index 1" in result
+
+    async def test_append_doc_text(self, mock_call_router):
+        mock_call_router.return_value = {
+            "document_id": "d1", "url": "https://...",
+        }
+        result = await append_doc_text(
+            user_google_email="t@t.com", document_id="d1", text="appended",
+        )
+        assert "Appended text to document" in result

--- a/tests/test_drive_router.py
+++ b/tests/test_drive_router.py
@@ -1,0 +1,117 @@
+"""Tests for Drive tools backed by the Apps Script router."""
+
+from unittest.mock import patch, AsyncMock
+
+import pytest
+
+from google_automation_mcp.tools.drive_router import (
+    search_drive_files,
+    list_drive_items,
+    get_drive_file_content,
+    create_drive_file,
+    create_drive_folder,
+    delete_drive_file,
+    trash_drive_file,
+    share_drive_file,
+    list_drive_permissions,
+    remove_drive_permission,
+)
+
+
+@pytest.fixture
+def mock_call_router():
+    with patch(
+        "google_automation_mcp.tools.drive_router.call_router",
+        new_callable=AsyncMock,
+    ) as mock:
+        yield mock
+
+
+@pytest.mark.asyncio
+class TestDriveRouterTools:
+    async def test_search_drive_files_success(self, mock_call_router):
+        mock_call_router.return_value = [
+            {"id": "f1", "name": "doc.txt", "mime_type": "text/plain",
+             "size": 1024, "modified": "2026-04-17T00:00:00Z", "url": "https://..."}
+        ]
+        result = await search_drive_files(user_google_email="t@t.com", query="doc")
+        assert "Found 1 files" in result
+        assert "doc.txt" in result
+
+    async def test_search_drive_files_empty(self, mock_call_router):
+        mock_call_router.return_value = []
+        result = await search_drive_files(user_google_email="t@t.com", query="nope")
+        assert "No files found" in result
+
+    async def test_list_drive_items(self, mock_call_router):
+        mock_call_router.return_value = {
+            "folders": [{"id": "d1", "name": "Folder1"}],
+            "files": [{"id": "f1", "name": "file.txt", "size": 100}],
+        }
+        result = await list_drive_items(user_google_email="t@t.com")
+        assert "Found 2 items" in result
+        assert "Folder1" in result
+        assert "file.txt" in result
+
+    async def test_list_drive_items_empty(self, mock_call_router):
+        mock_call_router.return_value = {"folders": [], "files": []}
+        result = await list_drive_items(user_google_email="t@t.com")
+        assert "No items found" in result
+
+    async def test_get_drive_file_content(self, mock_call_router):
+        mock_call_router.return_value = {
+            "id": "f1", "name": "readme.txt", "mime_type": "text/plain",
+            "url": "https://...", "content": "Hello world",
+        }
+        result = await get_drive_file_content(user_google_email="t@t.com", file_id="f1")
+        assert "readme.txt" in result
+        assert "Hello world" in result
+
+    async def test_create_drive_file(self, mock_call_router):
+        mock_call_router.return_value = {"id": "f1", "name": "new.txt", "url": "https://..."}
+        result = await create_drive_file(user_google_email="t@t.com", file_name="new.txt")
+        assert "Created file: new.txt" in result
+
+    async def test_create_drive_folder(self, mock_call_router):
+        mock_call_router.return_value = {"id": "d1", "name": "NewFolder", "url": "https://..."}
+        result = await create_drive_folder(user_google_email="t@t.com", folder_name="NewFolder")
+        assert "Created folder: NewFolder" in result
+
+    async def test_delete_drive_file(self, mock_call_router):
+        mock_call_router.return_value = {"deleted": True}
+        result = await delete_drive_file(user_google_email="t@t.com", file_id="f1")
+        assert "Permanently deleted" in result
+
+    async def test_trash_drive_file(self, mock_call_router):
+        mock_call_router.return_value = {"trashed": True}
+        result = await trash_drive_file(user_google_email="t@t.com", file_id="f1")
+        assert "Moved to trash" in result
+
+    async def test_share_drive_file(self, mock_call_router):
+        mock_call_router.return_value = {"shared": True}
+        result = await share_drive_file(
+            user_google_email="t@t.com", file_id="f1", email="b@b.com", role="writer"
+        )
+        assert "Shared file" in result
+        assert "b@b.com" in result
+
+    async def test_list_drive_permissions(self, mock_call_router):
+        mock_call_router.return_value = {
+            "file_id": "f1",
+            "permissions": [{"email": "a@a.com", "role": "writer"}],
+        }
+        result = await list_drive_permissions(user_google_email="t@t.com", file_id="f1")
+        assert "a@a.com" in result
+        assert "writer" in result
+
+    async def test_list_drive_permissions_empty(self, mock_call_router):
+        mock_call_router.return_value = {"file_id": "f1", "permissions": []}
+        result = await list_drive_permissions(user_google_email="t@t.com", file_id="f1")
+        assert "No permissions found" in result
+
+    async def test_remove_drive_permission(self, mock_call_router):
+        mock_call_router.return_value = {"removed": True}
+        result = await remove_drive_permission(
+            user_google_email="t@t.com", file_id="f1", permission_id="p1"
+        )
+        assert "Removed permission p1" in result

--- a/tests/test_forms_router.py
+++ b/tests/test_forms_router.py
@@ -1,0 +1,81 @@
+"""Tests for Forms tools backed by the Apps Script router."""
+
+from unittest.mock import patch, AsyncMock
+
+import pytest
+
+from google_automation_mcp.tools.forms_router import (
+    get_form,
+    get_form_responses,
+    create_form,
+    add_form_question,
+)
+
+
+@pytest.fixture
+def mock_call_router():
+    with patch(
+        "google_automation_mcp.tools.forms_router.call_router",
+        new_callable=AsyncMock,
+    ) as mock:
+        yield mock
+
+
+@pytest.mark.asyncio
+class TestFormsRouterTools:
+    async def test_get_form(self, mock_call_router):
+        mock_call_router.return_value = {
+            "form_id": "f1", "title": "Survey", "description": "A survey",
+            "url": "https://...", "edit_url": "https://...",
+            "items": [{"index": 1, "title": "Name?", "item_id": "q1", "type": "TEXT"}],
+        }
+        result = await get_form(user_google_email="t@t.com", form_id="f1")
+        assert "Survey" in result
+        assert "Name?" in result
+
+    async def test_get_form_responses(self, mock_call_router):
+        mock_call_router.return_value = [
+            {"response_id": "r1", "timestamp": "2026-04-17T00:00:00Z",
+             "answers": [{"question": "Name?", "answer": "Alice"}]},
+        ]
+        result = await get_form_responses(user_google_email="t@t.com", form_id="f1")
+        assert "Found 1 responses" in result
+        assert "Alice" in result
+
+    async def test_get_form_responses_empty(self, mock_call_router):
+        mock_call_router.return_value = []
+        result = await get_form_responses(user_google_email="t@t.com", form_id="f1")
+        assert "No responses found" in result
+
+    async def test_create_form(self, mock_call_router):
+        mock_call_router.return_value = {
+            "form_id": "f1", "title": "New Form",
+            "url": "https://...", "edit_url": "https://...",
+        }
+        result = await create_form(user_google_email="t@t.com", title="New Form")
+        assert "Created form: New Form" in result
+
+    async def test_add_form_question_text(self, mock_call_router):
+        mock_call_router.return_value = {"form_id": "f1", "title": "Email?", "type": "TEXT"}
+        result = await add_form_question(
+            user_google_email="t@t.com", form_id="f1", title="Email?",
+        )
+        assert "Added question 'Email?'" in result
+
+    async def test_add_form_question_choice_missing(self, mock_call_router):
+        result = await add_form_question(
+            user_google_email="t@t.com", form_id="f1", title="Pick one",
+            question_type="MULTIPLE_CHOICE",
+        )
+        assert "requires choices" in result
+        mock_call_router.assert_not_called()
+
+    async def test_add_form_question_choice(self, mock_call_router):
+        mock_call_router.return_value = {
+            "form_id": "f1", "title": "Color?", "type": "MULTIPLE_CHOICE",
+        }
+        result = await add_form_question(
+            user_google_email="t@t.com", form_id="f1", title="Color?",
+            question_type="MULTIPLE_CHOICE", choices="Red,Blue,Green",
+        )
+        assert "Added question 'Color?'" in result

--- a/tests/test_gmail_router.py
+++ b/tests/test_gmail_router.py
@@ -1,0 +1,205 @@
+"""Tests for Gmail tools backed by the Apps Script router."""
+
+from unittest.mock import patch, AsyncMock
+
+import pytest
+
+from google_automation_mcp.tools.gmail_router import (
+    search_gmail_messages,
+    get_gmail_message,
+    send_gmail_message,
+    list_gmail_labels,
+    modify_gmail_labels,
+)
+
+
+@pytest.fixture
+def mock_call_router():
+    with patch(
+        "google_automation_mcp.tools.gmail_router.call_router",
+        new_callable=AsyncMock,
+    ) as mock:
+        yield mock
+
+
+@pytest.mark.asyncio
+class TestGmailRouterTools:
+    async def test_search_gmail_messages_success(self, mock_call_router):
+        mock_call_router.return_value = [
+            {
+                "id": "thread1",
+                "message_id": "msg1",
+                "subject": "Test Subject",
+                "from": "sender@example.com",
+                "to": "me@example.com",
+                "date": "2026-04-15T10:00:00.000Z",
+                "snippet": "This is a test email",
+                "labels": ["INBOX"],
+                "unread": True,
+                "message_count": 1,
+            }
+        ]
+
+        result = await search_gmail_messages(
+            user_google_email="test@example.com", query="test"
+        )
+
+        assert "Found 1 messages" in result
+        assert "msg1" in result
+        assert "Test Subject" in result
+        assert "sender@example.com" in result
+        mock_call_router.assert_called_once_with(
+            "test@example.com",
+            "search_gmail",
+            {"query": "test", "max_results": 10},
+        )
+
+    async def test_search_gmail_messages_empty(self, mock_call_router):
+        mock_call_router.return_value = []
+
+        result = await search_gmail_messages(
+            user_google_email="test@example.com", query="nonexistent"
+        )
+
+        assert "No messages found" in result
+
+    async def test_get_gmail_message_success(self, mock_call_router):
+        mock_call_router.return_value = {
+            "id": "msg1",
+            "thread_id": "thread1",
+            "subject": "Test Subject",
+            "from": "sender@example.com",
+            "to": "me@example.com",
+            "cc": "",
+            "bcc": "",
+            "date": "2026-04-15T10:00:00.000Z",
+            "body": "Hello, this is the email body.",
+            "is_html": False,
+            "starred": False,
+            "unread": True,
+            "attachments": [],
+        }
+
+        result = await get_gmail_message(
+            user_google_email="test@example.com", message_id="msg1"
+        )
+
+        assert "msg1" in result
+        assert "Test Subject" in result
+        assert "Hello, this is the email body." in result
+        mock_call_router.assert_called_once_with(
+            "test@example.com",
+            "get_gmail_message",
+            {"message_id": "msg1"},
+        )
+
+    async def test_get_gmail_message_with_attachments(self, mock_call_router):
+        mock_call_router.return_value = {
+            "id": "msg2",
+            "thread_id": "thread2",
+            "subject": "With Attachment",
+            "from": "sender@example.com",
+            "to": "me@example.com",
+            "cc": "cc@example.com",
+            "bcc": "",
+            "date": "2026-04-15T10:00:00.000Z",
+            "body": "See attached.",
+            "is_html": False,
+            "starred": False,
+            "unread": False,
+            "attachments": [
+                {"name": "doc.pdf", "type": "application/pdf", "size": 12345}
+            ],
+        }
+
+        result = await get_gmail_message(
+            user_google_email="test@example.com", message_id="msg2"
+        )
+
+        assert "Attachments: 1" in result
+        assert "doc.pdf" in result
+
+    async def test_send_gmail_message_success(self, mock_call_router):
+        mock_call_router.return_value = {
+            "sent": True,
+            "to": "recipient@example.com",
+            "subject": "Hello",
+        }
+
+        result = await send_gmail_message(
+            user_google_email="test@example.com",
+            to="recipient@example.com",
+            subject="Hello",
+            body="Hi there!",
+        )
+
+        assert "Message sent successfully" in result
+        assert "recipient@example.com" in result
+        mock_call_router.assert_called_once_with(
+            "test@example.com",
+            "send_gmail",
+            {
+                "to": "recipient@example.com",
+                "subject": "Hello",
+                "body": "Hi there!",
+                "cc": None,
+                "bcc": None,
+                "html": False,
+            },
+        )
+
+    async def test_list_gmail_labels_success(self, mock_call_router):
+        mock_call_router.return_value = {
+            "user_labels": [
+                {"name": "Work"},
+                {"name": "Personal"},
+            ],
+            "note": "System labels not available via Apps Script",
+        }
+
+        result = await list_gmail_labels(user_google_email="test@example.com")
+
+        assert "Found 2 user labels" in result
+        assert "Work" in result
+        assert "Personal" in result
+        assert "Note:" in result
+
+    async def test_modify_gmail_labels_add(self, mock_call_router):
+        mock_call_router.return_value = {
+            "message_id": "msg1",
+            "added": ["STARRED"],
+            "removed": [],
+        }
+
+        result = await modify_gmail_labels(
+            user_google_email="test@example.com",
+            message_id="msg1",
+            add_labels=["STARRED"],
+        )
+
+        assert "Modified message: msg1" in result
+        assert "Added: STARRED" in result
+
+    async def test_modify_gmail_labels_remove(self, mock_call_router):
+        mock_call_router.return_value = {
+            "message_id": "msg1",
+            "added": [],
+            "removed": ["UNREAD", "INBOX"],
+        }
+
+        result = await modify_gmail_labels(
+            user_google_email="test@example.com",
+            message_id="msg1",
+            remove_labels=["UNREAD", "INBOX"],
+        )
+
+        assert "Removed: UNREAD, INBOX" in result
+
+    async def test_modify_gmail_labels_no_changes(self, mock_call_router):
+        result = await modify_gmail_labels(
+            user_google_email="test@example.com",
+            message_id="msg1",
+        )
+
+        assert "No labels to modify" in result
+        mock_call_router.assert_not_called()

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -2,7 +2,7 @@
 
 import json
 from unittest.mock import patch, AsyncMock, MagicMock
-
+from urllib.error import URLError, HTTPError
 import pytest
 
 from google_automation_mcp.router.client import call_router, RouterError
@@ -10,8 +10,21 @@ from google_automation_mcp.router.deployer import (
     _load_state,
     _save_state,
     _get_script_source,
+    _get_manifest,
+    _create_script_project,
+    _upload_script_content,
+    _create_version,
+    _create_web_app_deployment,
+    _update_deployment,
+    deploy_router,
+    update_router,
     ensure_router_deployed,
 )
+
+
+# =============================================================================
+# Router Client Tests
+# =============================================================================
 
 
 class TestRouterClient:
@@ -63,8 +76,54 @@ class TestRouterClient:
             with pytest.raises(RouterError, match="not found"):
                 await call_router("t@t.com", "bad_action", {})
 
+    @pytest.mark.asyncio
+    async def test_call_router_http_error(self):
+        mock_state = {
+            "web_app_url": "https://script.google.com/macros/s/test/exec",
+            "secret": "test-secret",
+        }
 
-class TestRouterDeployer:
+        with patch(
+            "google_automation_mcp.router.client.ensure_router_deployed",
+            new_callable=AsyncMock,
+            return_value=mock_state,
+        ), patch(
+            "google_automation_mcp.router.client.urlopen",
+        ) as mock_urlopen:
+            err = HTTPError(
+                "https://...", 403, "Forbidden", {}, MagicMock(read=lambda: b"denied")
+            )
+            mock_urlopen.side_effect = err
+
+            with pytest.raises(RouterError, match="HTTP 403"):
+                await call_router("t@t.com", "test", {})
+
+    @pytest.mark.asyncio
+    async def test_call_router_url_error(self):
+        mock_state = {
+            "web_app_url": "https://script.google.com/macros/s/test/exec",
+            "secret": "test-secret",
+        }
+
+        with patch(
+            "google_automation_mcp.router.client.ensure_router_deployed",
+            new_callable=AsyncMock,
+            return_value=mock_state,
+        ), patch(
+            "google_automation_mcp.router.client.urlopen",
+        ) as mock_urlopen:
+            mock_urlopen.side_effect = URLError("timeout")
+
+            with pytest.raises(RouterError, match="Connection error"):
+                await call_router("t@t.com", "test", {})
+
+
+# =============================================================================
+# Router Deployer Tests
+# =============================================================================
+
+
+class TestDeployerHelpers:
     def test_load_state_missing(self, tmp_path):
         with patch("google_automation_mcp.router.deployer.ROUTER_STATE_DIR", tmp_path):
             assert _load_state("nobody@example.com") is None
@@ -82,21 +141,167 @@ class TestRouterDeployer:
         assert "{{MCP_SECRET}}" not in source
         assert "function doPost" in source
 
+    def test_get_manifest(self):
+        manifest = _get_manifest()
+        parsed = json.loads(manifest)
+        assert "webapp" in parsed
+        assert parsed["webapp"]["access"] == "ANYONE_ANONYMOUS"
+
+
+@pytest.fixture
+def mock_script_service():
+    service = MagicMock()
+    with patch(
+        "google_automation_mcp.router.deployer.get_script_service",
+        return_value=service,
+    ):
+        yield service
+
+
+class TestDeployerApiCalls:
     @pytest.mark.asyncio
-    async def test_ensure_router_deployed_existing(self, tmp_path):
+    async def test_create_script_project(self, mock_script_service):
+        mock_script_service.projects().create().execute.return_value = {
+            "scriptId": "new-script-id"
+        }
+        result = await _create_script_project("Test")
+        assert result == "new-script-id"
+
+    @pytest.mark.asyncio
+    async def test_create_script_project_api_disabled(self, mock_script_service):
+        from googleapiclient.errors import HttpError
+
+        resp = MagicMock(status=403)
+        err = HttpError(resp, b"User has not enabled the Apps Script API")
+        mock_script_service.projects().create().execute.side_effect = err
+
+        with pytest.raises(RuntimeError, match="Apps Script API is not enabled"):
+            await _create_script_project("Test")
+
+    @pytest.mark.asyncio
+    async def test_upload_script_content(self, mock_script_service):
+        mock_script_service.projects().updateContent().execute.return_value = {}
+        await _upload_script_content("script-id", "secret-token")
+        mock_script_service.projects().updateContent.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_create_version(self, mock_script_service):
+        mock_script_service.projects().versions().create().execute.return_value = {
+            "versionNumber": 3
+        }
+        result = await _create_version("script-id", "v3")
+        assert result == 3
+
+    @pytest.mark.asyncio
+    async def test_create_web_app_deployment(self, mock_script_service):
+        mock_script_service.projects().deployments().create().execute.return_value = {
+            "deploymentId": "deploy-123"
+        }
+        result = await _create_web_app_deployment("script-id", 1)
+        assert "deploy-123" in result
+        assert result.startswith("https://script.google.com/macros/s/")
+
+    @pytest.mark.asyncio
+    async def test_update_deployment(self, mock_script_service):
+        mock_script_service.projects().deployments().update().execute.return_value = {}
+        result = await _update_deployment("script-id", "deploy-123", 2)
+        assert "deploy-123" in result
+
+
+class TestDeployRouter:
+    @pytest.mark.asyncio
+    async def test_deploy_router(self, tmp_path, mock_script_service):
+        mock_script_service.projects().create().execute.return_value = {
+            "scriptId": "new-id"
+        }
+        mock_script_service.projects().updateContent().execute.return_value = {}
+        mock_script_service.projects().versions().create().execute.return_value = {
+            "versionNumber": 1
+        }
+        mock_script_service.projects().deployments().create().execute.return_value = {
+            "deploymentId": "dep-1"
+        }
+
         with patch("google_automation_mcp.router.deployer.ROUTER_STATE_DIR", tmp_path):
-            state = {
-                "user_email": "t@t.com",
-                "script_id": "abc",
-                "web_app_url": "https://script.google.com/macros/s/abc/exec",
-                "secret": "s",
+            state = await deploy_router("user@test.com")
+
+        assert state["script_id"] == "new-id"
+        assert "dep-1" in state["web_app_url"]
+        assert len(state["secret"]) > 20
+        assert _load_state.__wrapped__ if hasattr(_load_state, "__wrapped__") else True
+
+    @pytest.mark.asyncio
+    async def test_update_router_existing(self, tmp_path, mock_script_service):
+        with patch("google_automation_mcp.router.deployer.ROUTER_STATE_DIR", tmp_path):
+            _save_state("user@test.com", {
+                "script_id": "existing-id", "secret": "old-secret",
+                "web_app_url": "https://old", "version": 1,
+            })
+
+            mock_script_service.projects().updateContent().execute.return_value = {}
+            mock_script_service.projects().versions().create().execute.return_value = {
+                "versionNumber": 2
             }
-            _save_state("t@t.com", state)
+            mock_script_service.projects().deployments().list().execute.return_value = {
+                "deployments": [
+                    {"deploymentId": "dep-1", "deploymentConfig": {"description": "MCP Router"}}
+                ]
+            }
+            mock_script_service.projects().deployments().update().execute.return_value = {}
+
+            state = await update_router("user@test.com")
+
+        assert state["version"] == 2
+        assert "dep-1" in state["web_app_url"]
+
+    @pytest.mark.asyncio
+    async def test_update_router_no_existing_deployment(self, tmp_path, mock_script_service):
+        with patch("google_automation_mcp.router.deployer.ROUTER_STATE_DIR", tmp_path):
+            _save_state("user@test.com", {
+                "script_id": "existing-id", "secret": "old-secret",
+                "web_app_url": "https://old", "version": 1,
+            })
+
+            mock_script_service.projects().updateContent().execute.return_value = {}
+            mock_script_service.projects().versions().create().execute.return_value = {
+                "versionNumber": 2
+            }
+            mock_script_service.projects().deployments().list().execute.return_value = {
+                "deployments": []
+            }
+            mock_script_service.projects().deployments().create().execute.return_value = {
+                "deploymentId": "dep-new"
+            }
+
+            state = await update_router("user@test.com")
+
+        assert "dep-new" in state["web_app_url"]
+
+    @pytest.mark.asyncio
+    async def test_update_router_no_state_falls_back_to_deploy(self, tmp_path):
+        with patch("google_automation_mcp.router.deployer.ROUTER_STATE_DIR", tmp_path), \
+             patch(
+                 "google_automation_mcp.router.deployer.deploy_router",
+                 new_callable=AsyncMock,
+                 return_value={"script_id": "fresh", "web_app_url": "https://new", "secret": "s"},
+             ) as mock_deploy:
+            state = await update_router("new@test.com")
+            assert state["script_id"] == "fresh"
+            mock_deploy.assert_called_once()
+
+
+class TestEnsureRouterDeployed:
+    @pytest.mark.asyncio
+    async def test_existing_state(self, tmp_path):
+        with patch("google_automation_mcp.router.deployer.ROUTER_STATE_DIR", tmp_path):
+            _save_state("t@t.com", {
+                "script_id": "abc", "web_app_url": "https://...", "secret": "s",
+            })
             result = await ensure_router_deployed("t@t.com")
             assert result["script_id"] == "abc"
 
     @pytest.mark.asyncio
-    async def test_ensure_router_deployed_new(self, tmp_path):
+    async def test_no_state_triggers_deploy(self, tmp_path):
         with patch("google_automation_mcp.router.deployer.ROUTER_STATE_DIR", tmp_path), \
              patch(
                  "google_automation_mcp.router.deployer.deploy_router",
@@ -105,4 +310,4 @@ class TestRouterDeployer:
              ) as mock_deploy:
             result = await ensure_router_deployed("new@example.com")
             assert result["script_id"] == "new"
-            mock_deploy.assert_called_once_with("new@example.com")
+            mock_deploy.assert_called_once()

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -1,0 +1,108 @@
+"""Tests for the router client and deployer."""
+
+import json
+from unittest.mock import patch, AsyncMock, MagicMock
+
+import pytest
+
+from google_automation_mcp.router.client import call_router, RouterError
+from google_automation_mcp.router.deployer import (
+    _load_state,
+    _save_state,
+    _get_script_source,
+    ensure_router_deployed,
+)
+
+
+class TestRouterClient:
+    @pytest.mark.asyncio
+    async def test_call_router_success(self):
+        mock_state = {
+            "web_app_url": "https://script.google.com/macros/s/test/exec",
+            "secret": "test-secret",
+        }
+        mock_response = json.dumps({"result": [{"id": "1", "name": "test"}]})
+
+        with patch(
+            "google_automation_mcp.router.client.ensure_router_deployed",
+            new_callable=AsyncMock,
+            return_value=mock_state,
+        ), patch(
+            "google_automation_mcp.router.client.urlopen",
+        ) as mock_urlopen:
+            mock_resp = MagicMock()
+            mock_resp.read.return_value = mock_response.encode()
+            mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+            mock_resp.__exit__ = MagicMock(return_value=False)
+            mock_urlopen.return_value = mock_resp
+
+            result = await call_router("t@t.com", "list_drive", {"folder_id": "root"})
+            assert result == [{"id": "1", "name": "test"}]
+
+    @pytest.mark.asyncio
+    async def test_call_router_error_response(self):
+        mock_state = {
+            "web_app_url": "https://script.google.com/macros/s/test/exec",
+            "secret": "test-secret",
+        }
+        mock_response = json.dumps({"error": "not found", "code": 404})
+
+        with patch(
+            "google_automation_mcp.router.client.ensure_router_deployed",
+            new_callable=AsyncMock,
+            return_value=mock_state,
+        ), patch(
+            "google_automation_mcp.router.client.urlopen",
+        ) as mock_urlopen:
+            mock_resp = MagicMock()
+            mock_resp.read.return_value = mock_response.encode()
+            mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+            mock_resp.__exit__ = MagicMock(return_value=False)
+            mock_urlopen.return_value = mock_resp
+
+            with pytest.raises(RouterError, match="not found"):
+                await call_router("t@t.com", "bad_action", {})
+
+
+class TestRouterDeployer:
+    def test_load_state_missing(self, tmp_path):
+        with patch("google_automation_mcp.router.deployer.ROUTER_STATE_DIR", tmp_path):
+            assert _load_state("nobody@example.com") is None
+
+    def test_save_and_load_state(self, tmp_path):
+        with patch("google_automation_mcp.router.deployer.ROUTER_STATE_DIR", tmp_path):
+            state = {"script_id": "abc", "web_app_url": "https://...", "secret": "s"}
+            _save_state("test@example.com", state)
+            loaded = _load_state("test@example.com")
+            assert loaded["script_id"] == "abc"
+
+    def test_get_script_source(self):
+        source = _get_script_source("my-secret-token")
+        assert "my-secret-token" in source
+        assert "{{MCP_SECRET}}" not in source
+        assert "function doPost" in source
+
+    @pytest.mark.asyncio
+    async def test_ensure_router_deployed_existing(self, tmp_path):
+        with patch("google_automation_mcp.router.deployer.ROUTER_STATE_DIR", tmp_path):
+            state = {
+                "user_email": "t@t.com",
+                "script_id": "abc",
+                "web_app_url": "https://script.google.com/macros/s/abc/exec",
+                "secret": "s",
+            }
+            _save_state("t@t.com", state)
+            result = await ensure_router_deployed("t@t.com")
+            assert result["script_id"] == "abc"
+
+    @pytest.mark.asyncio
+    async def test_ensure_router_deployed_new(self, tmp_path):
+        with patch("google_automation_mcp.router.deployer.ROUTER_STATE_DIR", tmp_path), \
+             patch(
+                 "google_automation_mcp.router.deployer.deploy_router",
+                 new_callable=AsyncMock,
+                 return_value={"script_id": "new", "web_app_url": "https://...", "secret": "s"},
+             ) as mock_deploy:
+            result = await ensure_router_deployed("new@example.com")
+            assert result["script_id"] == "new"
+            mock_deploy.assert_called_once_with("new@example.com")

--- a/tests/test_sheets_router.py
+++ b/tests/test_sheets_router.py
@@ -1,0 +1,97 @@
+"""Tests for Sheets tools backed by the Apps Script router."""
+
+from unittest.mock import patch, AsyncMock
+
+import pytest
+
+from google_automation_mcp.tools.sheets_router import (
+    list_spreadsheets,
+    get_sheet_values,
+    update_sheet_values,
+    append_sheet_values,
+    create_spreadsheet,
+    get_spreadsheet_metadata,
+)
+
+
+@pytest.fixture
+def mock_call_router():
+    with patch(
+        "google_automation_mcp.tools.sheets_router.call_router",
+        new_callable=AsyncMock,
+    ) as mock:
+        yield mock
+
+
+@pytest.mark.asyncio
+class TestSheetsRouterTools:
+    async def test_list_spreadsheets(self, mock_call_router):
+        mock_call_router.return_value = [
+            {"id": "s1", "name": "Budget", "modified": "2026-04-17", "url": "https://..."}
+        ]
+        result = await list_spreadsheets(user_google_email="t@t.com")
+        assert "Found 1 spreadsheets" in result
+        assert "Budget" in result
+
+    async def test_list_spreadsheets_empty(self, mock_call_router):
+        mock_call_router.return_value = []
+        result = await list_spreadsheets(user_google_email="t@t.com")
+        assert "No spreadsheets found" in result
+
+    async def test_get_sheet_values(self, mock_call_router):
+        mock_call_router.return_value = {
+            "spreadsheet_id": "s1", "range": "Sheet1",
+            "values": [["Name", "Age"], ["Alice", "30"]],
+        }
+        result = await get_sheet_values(user_google_email="t@t.com", spreadsheet_id="s1")
+        assert "Row 1: Name | Age" in result
+        assert "Row 2: Alice | 30" in result
+
+    async def test_get_sheet_values_empty(self, mock_call_router):
+        mock_call_router.return_value = {"spreadsheet_id": "s1", "range": "Sheet1", "values": []}
+        result = await get_sheet_values(user_google_email="t@t.com", spreadsheet_id="s1")
+        assert "No data found" in result
+
+    async def test_update_sheet_values(self, mock_call_router):
+        mock_call_router.return_value = {
+            "range": "Sheet1!A1:B2", "updated_rows": 2, "updated_cells": 4,
+        }
+        result = await update_sheet_values(
+            user_google_email="t@t.com", spreadsheet_id="s1",
+            range="Sheet1!A1:B2", values=[["a", "b"], ["c", "d"]],
+        )
+        assert "Updated spreadsheet" in result
+        assert "Cells updated: 4" in result
+
+    async def test_append_sheet_values(self, mock_call_router):
+        mock_call_router.return_value = {
+            "updated_range": "Sheet1!A3", "updated_rows": 1, "updated_cells": 2,
+        }
+        result = await append_sheet_values(
+            user_google_email="t@t.com", spreadsheet_id="s1",
+            range="Sheet1", values=[["x", "y"]],
+        )
+        assert "Appended to spreadsheet" in result
+        assert "Rows added: 1" in result
+
+    async def test_create_spreadsheet(self, mock_call_router):
+        mock_call_router.return_value = {
+            "spreadsheet_id": "s1", "title": "New Sheet",
+            "sheets": ["Sheet1", "Data"], "url": "https://...",
+        }
+        result = await create_spreadsheet(
+            user_google_email="t@t.com", title="New Sheet", sheet_names=["Sheet1", "Data"]
+        )
+        assert "Created spreadsheet: New Sheet" in result
+        assert "Sheet1, Data" in result
+
+    async def test_get_spreadsheet_metadata(self, mock_call_router):
+        mock_call_router.return_value = {
+            "spreadsheet_id": "s1", "title": "Budget",
+            "sheets": [{"title": "Sheet1", "sheet_id": 0, "rows": 100, "cols": 26}],
+            "url": "https://...",
+        }
+        result = await get_spreadsheet_metadata(user_google_email="t@t.com", spreadsheet_id="s1")
+        assert "Budget" in result
+        assert "Sheet1" in result
+        assert "Rows: 100" in result

--- a/tests/test_tasks_router.py
+++ b/tests/test_tasks_router.py
@@ -1,0 +1,94 @@
+"""Tests for Tasks tools backed by the Apps Script router."""
+
+from unittest.mock import patch, AsyncMock
+
+import pytest
+
+from google_automation_mcp.tools.tasks_router import (
+    list_task_lists,
+    get_tasks,
+    create_task,
+    update_task,
+    delete_task,
+    complete_task,
+)
+
+
+@pytest.fixture
+def mock_call_router():
+    with patch(
+        "google_automation_mcp.tools.tasks_router.call_router",
+        new_callable=AsyncMock,
+    ) as mock:
+        yield mock
+
+
+@pytest.mark.asyncio
+class TestTasksRouterTools:
+    async def test_list_task_lists(self, mock_call_router):
+        mock_call_router.return_value = [
+            {"id": "tl1", "title": "My Tasks", "updated": "2026-04-17T00:00:00Z"},
+        ]
+        result = await list_task_lists(user_google_email="t@t.com")
+        assert "Found 1 task lists" in result
+        assert "My Tasks" in result
+
+    async def test_list_task_lists_empty(self, mock_call_router):
+        mock_call_router.return_value = []
+        result = await list_task_lists(user_google_email="t@t.com")
+        assert "No task lists found" in result
+
+    async def test_get_tasks(self, mock_call_router):
+        mock_call_router.return_value = [
+            {"id": "t1", "title": "Buy milk", "status": "needsAction",
+             "due": "2026-04-18T00:00:00Z", "notes": "2%"},
+            {"id": "t2", "title": "Done thing", "status": "completed",
+             "due": None, "notes": None},
+        ]
+        result = await get_tasks(user_google_email="t@t.com")
+        assert "Found 2 tasks" in result
+        assert "○ Buy milk" in result
+        assert "✓ Done thing" in result
+        assert "Due:" in result
+
+    async def test_get_tasks_empty(self, mock_call_router):
+        mock_call_router.return_value = []
+        result = await get_tasks(user_google_email="t@t.com")
+        assert "No tasks found" in result
+
+    async def test_create_task(self, mock_call_router):
+        mock_call_router.return_value = {
+            "id": "t1", "title": "New task", "status": "needsAction", "due": None,
+        }
+        result = await create_task(user_google_email="t@t.com", title="New task")
+        assert "Created task: New task" in result
+
+    async def test_create_task_with_due(self, mock_call_router):
+        mock_call_router.return_value = {
+            "id": "t1", "title": "Deadline task", "status": "needsAction",
+            "due": "2026-04-20T00:00:00Z",
+        }
+        result = await create_task(
+            user_google_email="t@t.com", title="Deadline task",
+            due="2026-04-20T00:00:00Z",
+        )
+        assert "Due:" in result
+
+    async def test_update_task(self, mock_call_router):
+        mock_call_router.return_value = {
+            "id": "t1", "title": "Updated", "status": "needsAction", "due": None,
+        }
+        result = await update_task(
+            user_google_email="t@t.com", task_id="t1", title="Updated",
+        )
+        assert "Updated task: Updated" in result
+
+    async def test_delete_task(self, mock_call_router):
+        mock_call_router.return_value = {"deleted": True}
+        result = await delete_task(user_google_email="t@t.com", task_id="t1")
+        assert "Deleted task: t1" in result
+
+    async def test_complete_task(self, mock_call_router):
+        mock_call_router.return_value = {"id": "t1", "title": "Done", "status": "completed"}
+        result = await complete_task(user_google_email="t@t.com", task_id="t1")
+        assert "Completed task: Done" in result


### PR DESCRIPTION
## Summary

- All 41 Workspace tools (Gmail, Drive, Sheets, Calendar, Docs, Forms, Tasks) now work through a per-user Apps Script Web App using **clasp auth only** — no GCP project, no OAuth consent screen, no client secrets
- Automatic backend selection: router when no OAuth credentials configured, REST API when available
- `gmcp auth` handles full setup: clasp login → API check → router deployment → scope authorization URL
- Fixed clasp token parsing for new `{"tokens":{"default":{...}}}` format

## How it works

1. On first use, MCP deploys a bundled Apps Script as a Web App via the Script API (clasp auth)
2. The Web App routes tool calls to built-in services (`GmailApp`, `DriveApp`, `SpreadsheetApp`, `CalendarApp`, `DocumentApp`, `FormApp`) and Tasks via REST
3. Each tool call is an HTTP POST to the Web App with a per-user secret token
4. Backend auto-selected: `MCP_USE_ROUTER=auto` (default), `true`, or `false`

## Test plan

- [x] 110 unit tests pass (REST path: `MCP_USE_ROUTER=false`)
- [x] 9 router-specific Gmail tests pass
- [x] Live-verified all 7 services against real Google account
- [x] `gmcp status` shows router deployment state
- [x] `gmcp auth` flow deploys router and prints authorization URL
- [x] Lint clean (`ruff check`)